### PR TITLE
Stream stdout

### DIFF
--- a/BUILD_BASE_IMAGE.md
+++ b/BUILD_BASE_IMAGE.md
@@ -50,18 +50,6 @@ This can be achieved as follows:
 
 * Enable the service: `systemctl enable testrunner.service`.
 
-## Running tests
-### Dependencies
-You will need `glibc-static` and `e2tools` on fedora to launch the guest VM.
-
-### Running a test
-Start the test VM by running `./launch-guest.sh` and inputting your password.
-In the test window output you will find the serial bus path which looks something like `/dev/pts/1`, copy this path.
-In a new terminal run `cargo build --bin test-manager` and then `sudo ./target/debug/test-manager /dev/pts/7 clean-app-install` to run the `clean-app-install` test.
-
-### Seeing the output
-In the guest you can see the output by running `sudo journalctl -f -u testrunner`
-
 # Creating a base Windows 10 image
 
 * Download a Windows ISO: https://www.microsoft.com/software-download/windows10

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -823,6 +823,8 @@ dependencies = [
  "env_logger",
  "err-derive",
  "futures",
+ "lazy_static",
+ "log",
  "tarpc",
  "test-rpc",
  "tokio",

--- a/README.md
+++ b/README.md
@@ -1,0 +1,11 @@
+# Running tests
+## Dependencies
+You will need `glibc-static` and `e2tools` on fedora to launch the guest VM.
+
+## Running a test
+Start the test VM by running `./launch-guest.sh` and inputting your password.
+In the test window output you will find the serial bus path which looks something like `/dev/pts/1`, copy this path.
+In a new terminal run `cargo build --bin test-manager` and then `sudo ./target/debug/test-manager /dev/pts/7 clean-app-install` to run the `clean-app-install` test.
+
+## Seeing the output
+In the guest you can see the output by running `sudo journalctl -f -u testrunner`

--- a/test-manager/src/logging.rs
+++ b/test-manager/src/logging.rs
@@ -1,0 +1,31 @@
+use tarpc::context;
+use test_rpc::ServiceClient;
+use crate::tests::Error;
+use std::future::Future;
+
+pub async fn print_log_on_error<F, R>(rpc: ServiceClient, test: F, test_name: &str) -> Result<(), Error>
+where 
+    F: Fn(ServiceClient) -> R,
+    R: Future<Output = Result<(), Error>>,
+{
+    let _flushed = rpc.try_poll_output(context::current()).await;
+
+    let result = test(rpc.clone()).await;
+
+    if result.is_err() {
+        println!("TEST {} errored with the following output", test_name);
+        let output_after_test = rpc.try_poll_output(context::current()).await.map_err(Error::Rpc)?;
+        match output_after_test {
+            Ok(output_after_test) => {
+                for output in output_after_test {
+                    println!("{}", output);
+                }
+            },
+            Err(e) => {
+                println!("could not get logs due to: {:?}", e);
+            }
+        }
+        println!("TEST END OF OUTPUT");
+    }
+    result
+}

--- a/test-manager/src/main.rs
+++ b/test-manager/src/main.rs
@@ -1,4 +1,6 @@
 mod tests;
+mod logging;
+use logging::print_log_on_error;
 
 use test_rpc::ServiceClient;
 use tokio_util::codec::{Decoder, LengthDelimitedCodec};
@@ -33,11 +35,11 @@ async fn main() -> Result<(), Error> {
     let transport = tarpc::serde_transport::new(framed, tokio_serde::formats::Json::default());
     let client = ServiceClient::new(tarpc::client::Config::default(), transport).spawn();
 
-    match args.next().as_ref().map(String::as_str) {
-        Some("clean-app-install") => tests::test_clean_app_install(client)
+    match args.next().as_deref() {
+        Some("clean-app-install") => print_log_on_error(client, tests::test_clean_app_install, "clean_app_install")
             .await
             .map_err(Error::ClientError)?,
-        Some("upgrade-app") => tests::test_app_upgrade(client)
+        Some("upgrade-app") => print_log_on_error(client, tests::test_app_upgrade, "test_app_upgrade")
             .await
             .map_err(Error::ClientError)?,
         _ => return Err(Error::UnknownRpc),

--- a/test-manager/src/tests/mod.rs
+++ b/test-manager/src/tests/mod.rs
@@ -15,10 +15,10 @@ const INSTALL_TIMEOUT: Duration = Duration::from_secs(60);
 #[derive(err_derive::Error, Debug)]
 pub enum Error {
     #[error(display = "RPC call failed")]
-    RpcError(tarpc::client::RpcError),
+    Rpc(tarpc::client::RpcError),
 
     #[error(display = "Package action failed")]
-    PackageError(&'static str, test_rpc::package::Error),
+    Package(&'static str, test_rpc::package::Error),
 
     #[error(display = "Found running daemon unexpectedly")]
     DaemonAlreadyRunning,
@@ -32,7 +32,7 @@ pub async fn test_clean_app_install(rpc: ServiceClient) -> Result<(), Error> {
     if rpc
         .mullvad_daemon_get_status(context::current())
         .await
-        .map_err(Error::RpcError)?
+        .map_err(Error::Rpc)?
         != ServiceStatus::NotRunning
     {
         return Err(Error::DaemonAlreadyRunning);
@@ -44,14 +44,14 @@ pub async fn test_clean_app_install(rpc: ServiceClient) -> Result<(), Error> {
 
     rpc.install_app(ctx, get_package_desc(&rpc, "current-app").await?)
         .await
-        .map_err(Error::RpcError)?
-        .map_err(|err| Error::PackageError("current app", err))?;
+        .map_err(Error::Rpc)?
+        .map_err(|err| Error::Package("current app", err))?;
 
     // verify that daemon is running
     if rpc
         .mullvad_daemon_get_status(context::current())
         .await
-        .map_err(Error::RpcError)?
+        .map_err(Error::Rpc)?
         != ServiceStatus::Running
     {
         return Err(Error::DaemonNotRunning);
@@ -65,7 +65,7 @@ pub async fn test_app_upgrade(rpc: ServiceClient) -> Result<(), Error> {
     if rpc
         .mullvad_daemon_get_status(context::current())
         .await
-        .map_err(Error::RpcError)?
+        .map_err(Error::Rpc)?
         != ServiceStatus::NotRunning
     {
         return Err(Error::DaemonAlreadyRunning);
@@ -77,14 +77,14 @@ pub async fn test_app_upgrade(rpc: ServiceClient) -> Result<(), Error> {
 
     rpc.install_app(ctx, get_package_desc(&rpc, "previous-app").await?)
         .await
-        .map_err(Error::RpcError)?
-        .map_err(|error| Error::PackageError("previous app", error))?;
+        .map_err(Error::Rpc)?
+        .map_err(|error| Error::Package("previous app", error))?;
 
     // verify that daemon is running
     if rpc
         .mullvad_daemon_get_status(context::current())
         .await
-        .map_err(Error::RpcError)?
+        .map_err(Error::Rpc)?
         != ServiceStatus::Running
     {
         return Err(Error::DaemonNotRunning);
@@ -99,14 +99,14 @@ pub async fn test_app_upgrade(rpc: ServiceClient) -> Result<(), Error> {
 
     rpc.install_app(ctx, get_package_desc(&rpc, "current-app").await?)
         .await
-        .map_err(Error::RpcError)?
-        .map_err(|error| Error::PackageError("current app", error))?;
+        .map_err(Error::Rpc)?
+        .map_err(|error| Error::Package("current app", error))?;
 
     // verify that daemon is running
     if rpc
         .mullvad_daemon_get_status(context::current())
         .await
-        .map_err(Error::RpcError)?
+        .map_err(Error::Rpc)?
         != ServiceStatus::Running
     {
         return Err(Error::DaemonNotRunning);
@@ -121,7 +121,7 @@ async fn get_package_desc(rpc: &ServiceClient, name: &str) -> Result<Package, Er
     match rpc
         .get_os(context::current())
         .await
-        .map_err(Error::RpcError)?
+        .map_err(Error::Rpc)?
     {
         meta::Os::Linux => Ok(Package {
             r#type: PackageType::Dpkg,

--- a/test-rpc/src/lib.rs
+++ b/test-rpc/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod meta;
 pub mod mullvad_daemon;
 pub mod package;
+pub mod logging;
 
 #[tarpc::service]
 pub trait Service {
@@ -9,6 +10,10 @@ pub trait Service {
         -> package::Result<package::InstallResult>;
 
     //async fn harvest_logs()
+
+    async fn poll_output() -> mullvad_daemon::Result<Vec<logging::Output>>;
+
+    async fn try_poll_output() -> mullvad_daemon::Result<Vec<logging::Output>>;
 
     /// Return the OS of the guest.
     async fn get_os() -> meta::Os;

--- a/test-rpc/src/logging.rs
+++ b/test-rpc/src/logging.rs
@@ -1,0 +1,17 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum Output {
+    StdOut(String),
+    StdErr(String),
+}
+
+impl std::fmt::Display for Output {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            Output::StdOut(s) => f.write_str(s),
+            Output::StdErr(s) => f.write_str(s),
+        }
+    }
+}
+

--- a/test-rpc/src/mullvad_daemon.rs
+++ b/test-rpc/src/mullvad_daemon.rs
@@ -3,6 +3,7 @@ use serde::{Deserialize, Serialize};
 #[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub enum Error {
     ConnectError,
+    CanNotGetOutput,
 }
 
 pub type Result<T> = std::result::Result<T, Error>;

--- a/test-runner/Cargo.toml
+++ b/test-runner/Cargo.toml
@@ -10,6 +10,8 @@ tokio = { version = "1.0", features = ["macros", "rt", "process", "time", "fs", 
 tokio-serial = "5.4.1"
 tokio-serde = { version = "*", features = ["json"] }
 err-derive = "0.3.1"
+log = "0.4.17"
+lazy_static = "1.4.0"
 
 test-rpc = { path = "../test-rpc" }
 

--- a/test-runner/src/logging.rs
+++ b/test-runner/src/logging.rs
@@ -1,0 +1,50 @@
+use lazy_static::lazy_static;
+use log::{Level, LevelFilter, Metadata, Record, SetLoggerError};
+use test_rpc::logging::Output;
+use tokio::sync::{
+    broadcast::{channel, Receiver, Sender},
+    Mutex,
+};
+
+const MAX_OUTPUT_BUFFER: usize = 10_000;
+lazy_static! {
+    pub static ref LOGGER: StdOutBuffer = {
+        let (sender, listener) = channel(MAX_OUTPUT_BUFFER);
+        StdOutBuffer(Mutex::new(listener), sender)
+    };
+}
+
+pub struct StdOutBuffer(pub Mutex<Receiver<Output>>, pub Sender<Output>);
+
+impl log::Log for StdOutBuffer {
+    fn enabled(&self, metadata: &Metadata) -> bool {
+        metadata.level() <= Level::Info
+    }
+
+    fn log(&self, record: &Record) {
+        if self.enabled(record.metadata()) {
+            match record.metadata().level() {
+                Level::Error | Level::Warn => {
+                    self.1
+                        .send(Output::StdErr(format!("{}", record.args())))
+                        .unwrap();
+                }
+                Level::Info => {
+                    if !record.metadata().target().contains("tarpc") {
+                        self.1
+                            .send(Output::StdErr(format!("{}", record.args())))
+                            .unwrap();
+                    }
+                },
+                _ => (),
+            }
+            println!("{}", record.args());
+        }
+    }
+
+    fn flush(&self) {}
+}
+
+pub fn init_logger() -> Result<(), SetLoggerError> {
+    log::set_logger(&*LOGGER).map(|()| log::set_max_level(LevelFilter::Info))
+}


### PR DESCRIPTION
Creates a logging system that logs errors in the tests. When debugging you may also want to use the `try_poll_output` function in order to get a better understanding of what is happening in the guest.

We should try to use `log::info!` instead of `println!` in the guest as much as possible, but that's not something I've overly focused on in this PR.