### PR TITLE
Expose Mullvad daemon interface directly to the test manager

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -33,10 +33,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1485d4d2cc45e7b201ee3767015c96faa5904387c9d87c6efdd0fb511f12d305"
+
+[[package]]
+name = "async-stream"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dad5c83079eae9969be7fadefe640a1c566901f05ff91ab221de4b6f68d9507e"
+dependencies = [
+ "async-stream-impl",
+ "futures-core",
+]
+
+[[package]]
+name = "async-stream-impl"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10f203db73a71dfa2fb6dd22763990fa26f3d2625a6da2da900d23b87d26be27"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "async-trait"
@@ -67,6 +97,57 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
+name = "axum"
+version = "0.5.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acee9fd5073ab6b045a275b3e709c163dd36c90685219cb21804a147b58dba43"
+dependencies = [
+ "async-trait",
+ "axum-core",
+ "bitflags",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "hyper",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde",
+ "sync_wrapper",
+ "tokio",
+ "tower",
+ "tower-http",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37e5939e02c56fecd5c017c37df4238c0a839fa76b7f97acdd7efb804fd181cc"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "mime",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "base64"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -77,6 +158,12 @@ name = "bumpalo"
 version = "3.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1ad822118d20d2c234f427000d5acc36eabe1e29a348c89b63dd60b13f28e5d"
+
+[[package]]
+name = "byteorder"
+version = "1.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
 name = "bytes"
@@ -91,10 +178,58 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2fff2a6927b3bb87f9595d67196a70493f627687a71d87a0d692242c33f58c11"
 
 [[package]]
+name = "cesu8"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
+
+[[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "chrono"
+version = "0.4.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfd4d1b31faaa3a89d7934dbded3111da0d2ef28e3ebccdb4f0179f5929d1ef1"
+dependencies = [
+ "iana-time-zone",
+ "js-sys",
+ "num-integer",
+ "num-traits",
+ "serde",
+ "time",
+ "wasm-bindgen",
+ "winapi",
+]
+
+[[package]]
+name = "codespan-reporting"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3538270d33cc669650c4b093848450d380def10c331d38c768e34cac80576e6e"
+dependencies = [
+ "termcolor",
+ "unicode-width",
+]
+
+[[package]]
+name = "combine"
+version = "4.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35ed6e9d84f0b51a7f52daf1c7d71dd136fd7a3f41a8462b8cdb8c78d920fad4"
+dependencies = [
+ "bytes",
+ "memchr",
+]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc"
 
 [[package]]
 name = "crossbeam-channel"
@@ -117,6 +252,93 @@ dependencies = [
 ]
 
 [[package]]
+name = "curve25519-dalek"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b9fdf9972b2bd6af2d913799d9ebc165ea4d2e65878e329d9c6b372c4491b61"
+dependencies = [
+ "byteorder",
+ "digest",
+ "rand_core 0.5.1",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "cxx"
+version = "1.0.79"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f83d0ebf42c6eafb8d7c52f7e5f2d3003b89c7aa4fd2b79229209459a849af8"
+dependencies = [
+ "cc",
+ "cxxbridge-flags",
+ "cxxbridge-macro",
+ "link-cplusplus",
+]
+
+[[package]]
+name = "cxx-build"
+version = "1.0.79"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07d050484b55975889284352b0ffc2ecbda25c0c55978017c132b29ba0818a86"
+dependencies = [
+ "cc",
+ "codespan-reporting",
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "scratch",
+ "syn",
+]
+
+[[package]]
+name = "cxxbridge-flags"
+version = "1.0.79"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99d2199b00553eda8012dfec8d3b1c75fce747cf27c169a270b3b99e3448ab78"
+
+[[package]]
+name = "cxxbridge-macro"
+version = "1.0.79"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcb67a6de1f602736dd7eaead0080cf3435df806c61b24b13328db128c58868f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "digest"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "dirs-next"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b98cf8ebf19c3d1b223e151f99a4f9f0690dca41414773390fc824184ac833e1"
+dependencies = [
+ "cfg-if",
+ "dirs-sys-next",
+]
+
+[[package]]
+name = "dirs-sys-next"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ebda144c4fe02d1f7ea1a7d9641b6fc6b580adcfa024ae48797ecdeb6825b4d"
+dependencies = [
+ "libc",
+ "redox_users",
+ "winapi",
+]
+
+[[package]]
 name = "educe"
 version = "0.4.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -127,6 +349,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "either"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90e5c1c8368803113bf0c9584fc495a58b86dc8a29edbf8fe877d21d9507e797"
 
 [[package]]
 name = "enum-ordinalize"
@@ -168,6 +396,21 @@ dependencies = [
  "syn",
  "synstructure",
 ]
+
+[[package]]
+name = "fastrand"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7a407cfaa3385c4ae6b23e84623d48c2798d06e3e6a1878f7f59f17b3f86499"
+dependencies = [
+ "instant",
+]
+
+[[package]]
+name = "fixedbitset"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
 name = "fnv"
@@ -265,6 +508,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "generic-array"
+version = "0.14.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bff49e947297f3312447abdca79f45f4738097cc82b06e72054d2223f601f1b9"
+dependencies = [
+ "typenum",
+ "version_check",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi 0.9.0+wasi-snapshot-preview1",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -272,8 +536,39 @@ checksum = "4eb1a864a501629691edf6c15a593b7a51eebaa1e8468e9ddc623de7c9b58ec6"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
 ]
+
+[[package]]
+name = "h2"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ca32592cf21ac7ccab1825cd87f6c9b3d9022c44d086172ed0966bec8af30be"
+dependencies = [
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "futures-util",
+ "http",
+ "indexmap",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+
+[[package]]
+name = "heck"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2540771e65fc8cb83cd6e8a237f70c319bd5c29f78ed1084ba5d50eeac86f7f9"
 
 [[package]]
 name = "hermit-abi"
@@ -285,16 +580,197 @@ dependencies = [
 ]
 
 [[package]]
+name = "http"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75f43d41e26995c17e71ee126451dd3941010b0514a81a9d11f3b341debc2399"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa",
+]
+
+[[package]]
+name = "http-body"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5f38f16d184e36f2408a55281cd658ecbd3ca05cce6d6510a176eca393e26d1"
+dependencies = [
+ "bytes",
+ "http",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "http-range-header"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bfe8eed0a9285ef776bb792479ea3834e8b94e13d615c2f66d03dd50a435a29"
+
+[[package]]
+name = "httparse"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d897f394bad6a705d5f4104762e116a75639e470d80901eed05a860a95cb1904"
+
+[[package]]
+name = "httpdate"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4a1e36c821dbe04574f602848a19f742f4fb3c98d40449f11bcad18d6b17421"
+
+[[package]]
 name = "humantime"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
+name = "hyper"
+version = "0.14.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02c929dc5c39e335a03c405292728118860721b10190d98c2a0f0efd5baafbac"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http",
+ "http-body",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project-lite",
+ "socket2",
+ "tokio",
+ "tower-service",
+ "tracing",
+ "want",
+]
+
+[[package]]
+name = "hyper-timeout"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbb958482e8c7be4bc3cf272a766a2b0bf1a6755e7a6ae777f017a31d11b13b1"
+dependencies = [
+ "hyper",
+ "pin-project-lite",
+ "tokio",
+ "tokio-io-timeout",
+]
+
+[[package]]
+name = "iana-time-zone"
+version = "0.1.51"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5a6ef98976b22b3b7f2f3a806f858cb862044cfa66805aa3ad84cb3d3b785ed"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "wasm-bindgen",
+ "winapi",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0703ae284fc167426161c2e3f1da3ea71d94b21bedbcc9494e92b28e334e3dca"
+dependencies = [
+ "cxx",
+ "cxx-build",
+]
+
+[[package]]
+name = "indexmap"
+version = "1.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10a35a97730320ffe8e2d410b5d3b69279b98d2c14bdb8b70ea89ecf7888d41e"
+dependencies = [
+ "autocfg",
+ "hashbrown",
+]
+
+[[package]]
+name = "instant"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "ipnetwork"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8eca9f51da27bc908ef3dd85c21e1bbba794edaf94d7841e37356275b82d31e"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4217ad341ebadf8d8e724e264f13e593e0648f5b3e94b3896a5df283be015ecc"
+
+[[package]]
+name = "jni"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6df18c2e3db7e453d3c6ac5b3e9d5182664d28788126d39b91f2d1e22b017ec"
+dependencies = [
+ "cesu8",
+ "combine",
+ "jni-sys",
+ "log",
+ "thiserror",
+ "walkdir",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
+
+[[package]]
+name = "jnix"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aecfa741840d59de75e6e9e2985ee44b6794cbc0b2074899089be6bf7ffa0afc"
+dependencies = [
+ "jni",
+ "jnix-macros",
+ "once_cell",
+ "parking_lot",
+]
+
+[[package]]
+name = "jnix-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "002f4dfe6d97ae88c33f3489c0d31ffc6f81d9a492de98ff113b127d73bafff8"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "js-sys"
@@ -316,6 +792,25 @@ name = "libc"
 version = "0.2.132"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8371e4e5341c3a96db127eb2465ac681ced4c433e01dd0e938adbef26ba93ba5"
+
+[[package]]
+name = "link-cplusplus"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9272ab7b96c9046fbc5bc56c06c117cb639fe2d509df0c421cad82d2915cf369"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "lock_api"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "435011366fe56583b16cf956f9df0095b405b82d76425bc8981c0e22e60ec4df"
+dependencies = [
+ "autocfg",
+ "scopeguard",
+]
 
 [[package]]
 name = "log"
@@ -345,6 +840,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "matchit"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73cbba799671b762df5a175adf59ce145165747bb891505c43d09aefbbf38beb"
+
+[[package]]
 name = "memchr"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -360,6 +861,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "mime"
+version = "0.3.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a60c7ce501c71e03a9c9c0d35b861413ae925bd979cc7a4e30d060069aaac8d"
+
+[[package]]
 name = "mio"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -367,8 +874,8 @@ checksum = "57ee1c23c7c63b0c9250c339ffdc69255f110b298b901b9f6c82547b7b87caaf"
 dependencies = [
  "libc",
  "log",
- "wasi",
- "windows-sys",
+ "wasi 0.11.0+wasi-snapshot-preview1",
+ "windows-sys 0.36.1",
 ]
 
 [[package]]
@@ -383,6 +890,59 @@ dependencies = [
  "serialport",
  "winapi",
 ]
+
+[[package]]
+name = "mullvad-management-interface"
+version = "0.0.0"
+dependencies = [
+ "chrono",
+ "err-derive",
+ "futures",
+ "lazy_static",
+ "log",
+ "mullvad-paths",
+ "mullvad-types",
+ "nix 0.23.1",
+ "parity-tokio-ipc",
+ "prost",
+ "prost-types",
+ "talpid-types",
+ "tokio",
+ "tonic",
+ "tonic-build",
+ "tower",
+]
+
+[[package]]
+name = "mullvad-paths"
+version = "0.0.0"
+dependencies = [
+ "dirs-next",
+ "err-derive",
+ "log",
+]
+
+[[package]]
+name = "mullvad-types"
+version = "0.0.0"
+dependencies = [
+ "chrono",
+ "err-derive",
+ "ipnetwork",
+ "jnix",
+ "lazy_static",
+ "log",
+ "rand 0.8.5",
+ "regex",
+ "serde",
+ "talpid-types",
+]
+
+[[package]]
+name = "multimap"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5ce46fe64a9d73be07dcbe690a38ce1b293be448fd8ce1e6c1b8062c9f72c6a"
 
 [[package]]
 name = "nix"
@@ -469,8 +1029,45 @@ dependencies = [
  "lazy_static",
  "percent-encoding",
  "pin-project",
- "rand",
+ "rand 0.8.5",
  "thiserror",
+]
+
+[[package]]
+name = "parity-tokio-ipc"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9981e32fb75e004cc148f5fb70342f393830e0a4aa62e3cc93b50976218d42b6"
+dependencies = [
+ "futures",
+ "libc",
+ "log",
+ "rand 0.7.3",
+ "tokio",
+ "winapi",
+]
+
+[[package]]
+name = "parking_lot"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4dc9e0dc2adc1c69d09143aff38d3d30c5c3f0df0dad82e6d25547af174ebec0"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
@@ -478,6 +1075,16 @@ name = "percent-encoding"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
+
+[[package]]
+name = "petgraph"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6d5014253a1331579ce62aa67443b4a658c5e7dd03d4bc6d302b94474888143"
+dependencies = [
+ "fixedbitset",
+ "indexmap",
+]
 
 [[package]]
 name = "pin-project"
@@ -518,6 +1125,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eb9f9e6e233e5c4a35559a617bf40a4ec447db2e84c20b55a6f83167b7e57872"
 
 [[package]]
+name = "prettyplease"
+version = "0.1.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c142c0e46b57171fe0c528bee8c5b7569e80f0c17e377cd0e30ea57dbc11bb51"
+dependencies = [
+ "proc-macro2",
+ "syn",
+]
+
+[[package]]
 name = "proc-macro-error"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -551,6 +1168,59 @@ dependencies = [
 ]
 
 [[package]]
+name = "prost"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "399c3c31cdec40583bb68f0b18403400d01ec4289c383aa047560439952c4dd7"
+dependencies = [
+ "bytes",
+ "prost-derive",
+]
+
+[[package]]
+name = "prost-build"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f835c582e6bd972ba8347313300219fed5bfa52caf175298d860b61ff6069bb"
+dependencies = [
+ "bytes",
+ "heck",
+ "itertools",
+ "lazy_static",
+ "log",
+ "multimap",
+ "petgraph",
+ "prost",
+ "prost-types",
+ "regex",
+ "tempfile",
+ "which",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7345d5f0e08c0536d7ac7229952590239e77abf0a0100a1b1d890add6ea96364"
+dependencies = [
+ "anyhow",
+ "itertools",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "prost-types"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4dfaa718ad76a44b3415e6c4d53b17c8f99160dcb3a99b10470fce8ad43f6e3e"
+dependencies = [
+ "bytes",
+ "prost",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -561,13 +1231,36 @@ dependencies = [
 
 [[package]]
 name = "rand"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
+dependencies = [
+ "getrandom 0.1.16",
+ "libc",
+ "rand_chacha 0.2.2",
+ "rand_core 0.5.1",
+ "rand_hc",
+]
+
+[[package]]
+name = "rand"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.3",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.5.1",
 ]
 
 [[package]]
@@ -577,7 +1270,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.3",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
+dependencies = [
+ "getrandom 0.1.16",
 ]
 
 [[package]]
@@ -586,7 +1288,36 @@ version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d34f1408f55294453790c48b2f1ebbb1c5b4b7563eb1f418bcfcfdbb06ebb4e7"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.7",
+]
+
+[[package]]
+name = "rand_hc"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
+dependencies = [
+ "rand_core 0.5.1",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b033d837a7cf162d7993aded9304e30a83213c648b6e389db233191f891e5c2b"
+dependencies = [
+ "getrandom 0.2.7",
+ "redox_syscall",
+ "thiserror",
 ]
 
 [[package]]
@@ -605,6 +1336,15 @@ name = "regex-syntax"
 version = "0.6.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a3f87b73ce11b1619a3c6332f45341e0047173771e8b8b73f87bfeefb7b56244"
+
+[[package]]
+name = "remove_dir_all"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
+dependencies = [
+ "winapi",
+]
 
 [[package]]
 name = "rustc_version"
@@ -626,6 +1366,27 @@ name = "ryu"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4501abdff3ae82a1c1b477a17252eb69cee9e66eb915c1abaa4f44d873df9f09"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
+name = "scopeguard"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
+
+[[package]]
+name = "scratch"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c8132065adcfd6e02db789d9285a0deb2f3fcb04002865ab67d5fb103533898"
 
 [[package]]
 name = "semver"
@@ -708,6 +1469,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "smallvec"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
+
+[[package]]
 name = "socket2"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -724,6 +1491,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
+name = "subtle"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
+
+[[package]]
 name = "syn"
 version = "1.0.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -733,6 +1506,12 @@ dependencies = [
  "quote",
  "unicode-ident",
 ]
+
+[[package]]
+name = "sync_wrapper"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20518fe4a4c9acf048008599e464deb21beeae3d3578418951a189c235a7a9a8"
 
 [[package]]
 name = "synstructure"
@@ -747,6 +1526,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "talpid-types"
+version = "0.0.0"
+dependencies = [
+ "base64",
+ "err-derive",
+ "ipnetwork",
+ "jnix",
+ "rand 0.8.5",
+ "serde",
+ "x25519-dalek",
+ "zeroize",
+]
+
+[[package]]
 name = "tarpc"
 version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -758,7 +1551,7 @@ dependencies = [
  "humantime",
  "opentelemetry",
  "pin-project",
- "rand",
+ "rand 0.8.5",
  "serde",
  "static_assertions",
  "tarpc-plugins",
@@ -782,6 +1575,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "tempfile"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cdb1ef4eaeeaddc8fbd371e5017057064af0911902ef36b39801f67cc6d79e4"
+dependencies = [
+ "cfg-if",
+ "fastrand",
+ "libc",
+ "redox_syscall",
+ "remove_dir_all",
+ "winapi",
+]
+
+[[package]]
 name = "termcolor"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -794,37 +1601,51 @@ dependencies = [
 name = "test-manager"
 version = "0.1.0"
 dependencies = [
+ "bytes",
  "env_logger",
  "err-derive",
  "futures",
- "serde",
+ "log",
+ "mullvad-management-interface",
+ "mullvad-types",
+ "talpid-types",
  "tarpc",
  "test-rpc",
  "tokio",
- "tokio-serde",
  "tokio-serial",
  "tokio-util",
+ "tonic",
+ "tower",
 ]
 
 [[package]]
 name = "test-rpc"
 version = "0.1.0"
 dependencies = [
+ "bytes",
  "err-derive",
  "futures",
+ "log",
  "serde",
+ "serde_json",
  "tarpc",
+ "tokio",
+ "tokio-serde",
+ "tokio-util",
 ]
 
 [[package]]
 name = "test-runner"
 version = "0.1.0"
 dependencies = [
- "env_logger",
+ "bytes",
  "err-derive",
  "futures",
  "lazy_static",
  "log",
+ "parity-tokio-ipc",
+ "serde",
+ "serde_json",
  "tarpc",
  "test-rpc",
  "tokio",
@@ -863,6 +1684,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "time"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6db9e6914ab8b1ae1c260a4ae7a49b6c5611b40328a735b21862567685e73255"
+dependencies = [
+ "libc",
+ "wasi 0.10.0+wasi-snapshot-preview1",
+ "winapi",
+]
+
+[[package]]
 name = "tokio"
 version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -880,6 +1712,16 @@ dependencies = [
  "socket2",
  "tokio-macros",
  "winapi",
+]
+
+[[package]]
+name = "tokio-io-timeout"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30b74022ada614a1b4834de765f9bb43877f910cc8ce4be40e89042c9223a8bf"
+dependencies = [
+ "pin-project-lite",
+ "tokio",
 ]
 
 [[package]]
@@ -922,6 +1764,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-stream"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d660770404473ccd7bc9f8b28494a811bc18542b915c0855c51e8f419d5223ce"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-util"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -935,6 +1788,102 @@ dependencies = [
  "tokio",
  "tracing",
 ]
+
+[[package]]
+name = "tonic"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55b9af819e54b8f33d453655bef9b9acc171568fb49523078d0cc4e7484200ec"
+dependencies = [
+ "async-stream",
+ "async-trait",
+ "axum",
+ "base64",
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http",
+ "http-body",
+ "hyper",
+ "hyper-timeout",
+ "percent-encoding",
+ "pin-project",
+ "prost",
+ "prost-derive",
+ "tokio",
+ "tokio-stream",
+ "tokio-util",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+ "tracing-futures",
+]
+
+[[package]]
+name = "tonic-build"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48c6fd7c2581e36d63388a9e04c350c21beb7a8b059580b2e93993c526899ddc"
+dependencies = [
+ "prettyplease",
+ "proc-macro2",
+ "prost-build",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tower"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "indexmap",
+ "pin-project",
+ "pin-project-lite",
+ "rand 0.8.5",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c530c8675c1dbf98facee631536fa116b5fb6382d7dd6dc1b118d970eafe3ba"
+dependencies = [
+ "bitflags",
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-range-header",
+ "pin-project-lite",
+ "tower",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c20c8dbed6283a09604c3e69b4b7eeb54e298b8a600d4d5ecb5ad39de609f1d0"
+
+[[package]]
+name = "tower-service"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6bc1c9ce2b5135ac7f93c72918fc37feb872bdc6a5533a8b85eb4b86bfdae52"
 
 [[package]]
 name = "tracing"
@@ -971,6 +1920,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-futures"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97d095ae15e245a057c8e8451bab9b3ee1e1f68e9ba2b4fbc18d0ac5237835f2"
+dependencies = [
+ "pin-project",
+ "tracing",
+]
+
+[[package]]
 name = "tracing-opentelemetry"
 version = "0.17.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -995,10 +1954,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "try-lock"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59547bce71d9c38b83d9c0e92b6066c4253371f15005def0c30d9657f50c7642"
+
+[[package]]
+name = "typenum"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcf81ac59edc17cc8697ff311e8f5ef2d99fcbd9817b34cec66f90b6c3dfd987"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4f5b37a154999a8f3f98cc23a628d850e154479cd94decf3414696e12e31aaf"
+
+[[package]]
+name = "unicode-width"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b"
 
 [[package]]
 name = "unicode-xid"
@@ -1017,6 +1994,39 @@ name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+
+[[package]]
+name = "walkdir"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "808cf2735cd4b6866113f648b791c6adc5714537bc222d9347bb203386ffda56"
+dependencies = [
+ "same-file",
+ "winapi",
+ "winapi-util",
+]
+
+[[package]]
+name = "want"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ce8a968cb1cd110d136ff8b819a556d6fb6d919363c61534f6860c7eb172ba0"
+dependencies = [
+ "log",
+ "try-lock",
+]
+
+[[package]]
+name = "wasi"
+version = "0.9.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
+
+[[package]]
+name = "wasi"
+version = "0.10.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
 
 [[package]]
 name = "wasi"
@@ -1079,6 +2089,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c38c045535d93ec4f0b4defec448e4291638ee608530863b1e2ba115d4fff7f"
 
 [[package]]
+name = "which"
+version = "4.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c831fbbee9e129a8cf93e7747a82da9d95ba8e16621cae60ec2cdc849bacb7b"
+dependencies = [
+ "either",
+ "libc",
+ "once_cell",
+]
+
+[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1115,12 +2136,33 @@ version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea04155a16a59f9eab786fe12a4a450e75cdb175f9e0d80da1e17db09f55b8d2"
 dependencies = [
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_msvc",
+ "windows_aarch64_msvc 0.36.1",
+ "windows_i686_gnu 0.36.1",
+ "windows_i686_msvc 0.36.1",
+ "windows_x86_64_gnu 0.36.1",
+ "windows_x86_64_msvc 0.36.1",
 ]
+
+[[package]]
+name = "windows-sys"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a3e1820f08b8513f676f7ab6c1f99ff312fb97b553d30ff4dd86f9f15728aa7"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc 0.42.0",
+ "windows_i686_gnu 0.42.0",
+ "windows_i686_msvc 0.42.0",
+ "windows_x86_64_gnu 0.42.0",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc 0.42.0",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41d2aa71f6f0cbe00ae5167d90ef3cfe66527d6f613ca78ac8024c3ccab9a19e"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -1129,10 +2171,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9bb8c3fd39ade2d67e9874ac4f3db21f0d710bee00fe7cab16949ec184eeaa47"
 
 [[package]]
+name = "windows_aarch64_msvc"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd0f252f5a35cac83d6311b2e795981f5ee6e67eb1f9a7f64eb4500fbc4dcdb4"
+
+[[package]]
 name = "windows_i686_gnu"
 version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "180e6ccf01daf4c426b846dfc66db1fc518f074baa793aa7d9b9aaeffad6a3b6"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbeae19f6716841636c28d695375df17562ca208b2b7d0dc47635a50ae6c5de7"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -1141,13 +2195,69 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2e7917148b2812d1eeafaeb22a97e4813dfa60a3f8f78ebe204bcc88f12f024"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84c12f65daa39dd2babe6e442988fc329d6243fdce47d7d2d155b8d874862246"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4dcd171b8776c41b97521e5da127a2d86ad280114807d0b2ab1e462bc764d9e1"
 
 [[package]]
+name = "windows_x86_64_gnu"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf7b1b21b5362cbc318f686150e5bcea75ecedc74dd157d874d754a2ca44b0ed"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09d525d2ba30eeb3297665bd434a54297e4170c7f1a44cad4ef58095b4cd2028"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c811ca4a8c853ef420abd8592ba53ddbbac90410fab6903b3e79972a631f7680"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40009d85759725a34da6d89a94e63d7bdc50a862acf0dbc7c8e488f1edcb6f5"
+
+[[package]]
+name = "x25519-dalek"
+version = "2.0.0-pre.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5da623d8af10a62342bcbbb230e33e58a63255a58012f8653c578e54bab48df"
+dependencies = [
+ "curve25519-dalek",
+ "rand_core 0.6.3",
+ "zeroize",
+]
+
+[[package]]
+name = "zeroize"
+version = "1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c394b5bd0c6f669e7275d9c20aa90ae064cb22e75a1cad54e1b34088034b149f"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f8f187641dad4f680d25c4bfc4225b418165984179f26ca76ec4fb6441d3a17"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]

--- a/test-manager/Cargo.toml
+++ b/test-manager/Cargo.toml
@@ -8,13 +8,20 @@ futures = "0.3"
 tarpc = { version = "0.30", features = ["tokio1", "serde-transport", "serde1"] }
 tokio = { version = "1.0", features = ["macros", "rt", "process", "time", "fs", "io-util", "rt-multi-thread"] }
 tokio-serial = "5.4.1"
-tokio-serde = { version = "*", features = ["json"] }
-serde = "*"
 err-derive = "0.3.1"
+bytes = "*"
+
+talpid-types = { path = "../../mullvadvpn-app/talpid-types" }
+mullvad-types = { path = "../../mullvadvpn-app/mullvad-types" }
 
 test-rpc = { path = "../test-rpc" }
 
 env_logger = "0.9"
+log = "0.4.17"
+
+tonic = "0.8"
+tower = "0.4"
+mullvad-management-interface = { path = "../../mullvadvpn-app/mullvad-management-interface" }
 
 [dependencies.tokio-util]
 version = "0.7"

--- a/test-manager/src/logging.rs
+++ b/test-manager/src/logging.rs
@@ -1,10 +1,14 @@
-use tarpc::context;
-use test_rpc::ServiceClient;
 use crate::tests::Error;
 use std::future::Future;
+use tarpc::context;
+use test_rpc::ServiceClient;
 
-pub async fn print_log_on_error<F, R>(rpc: ServiceClient, test: F, test_name: &str) -> Result<(), Error>
-where 
+pub async fn print_log_on_error<F, R>(
+    rpc: ServiceClient,
+    test: F,
+    test_name: &str,
+) -> Result<(), Error>
+where
     F: Fn(ServiceClient) -> R,
     R: Future<Output = Result<(), Error>>,
 {
@@ -14,13 +18,16 @@ where
 
     if result.is_err() {
         println!("TEST {} errored with the following output", test_name);
-        let output_after_test = rpc.try_poll_output(context::current()).await.map_err(Error::Rpc)?;
+        let output_after_test = rpc
+            .try_poll_output(context::current())
+            .await
+            .map_err(Error::Rpc)?;
         match output_after_test {
             Ok(output_after_test) => {
                 for output in output_after_test {
                     println!("{}", output);
                 }
-            },
+            }
             Err(e) => {
                 println!("could not get logs due to: {:?}", e);
             }

--- a/test-manager/src/mullvad_daemon.rs
+++ b/test-manager/src/mullvad_daemon.rs
@@ -1,0 +1,84 @@
+use futures::{pin_mut, SinkExt, StreamExt};
+use mullvad_management_interface::{
+    types::management_service_client::ManagementServiceClient, Channel,
+};
+use test_rpc::transport::GrpcForwarder;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio_util::codec::{Decoder, LengthDelimitedCodec};
+use tower::Service;
+
+struct DummyService(Option<GrpcForwarder>);
+
+impl<Request> Service<Request> for DummyService {
+    type Response = GrpcForwarder;
+    type Error = std::io::Error;
+    type Future = futures::future::Ready<Result<GrpcForwarder, Self::Error>>;
+
+    fn poll_ready(
+        &mut self,
+        _: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Result<(), Self::Error>> {
+        if self.0.is_some() {
+            std::task::Poll::Ready(Ok(()))
+        } else {
+            std::task::Poll::Pending
+        }
+    }
+
+    fn call(&mut self, _: Request) -> Self::Future {
+        let stream = self.0.take().expect("called more than once");
+        futures::future::ok(stream)
+    }
+}
+
+pub async fn new_rpc_client(
+    mullvad_daemon_transport: GrpcForwarder,
+) -> ManagementServiceClient<Channel> {
+    const CONVERTER_BUF_SIZE: usize = 16 * 1024;
+
+    let mut framed_transport = LengthDelimitedCodec::new().framed(mullvad_daemon_transport);
+
+    let (mut management_channel_in, management_channel_out) = tokio::io::duplex(CONVERTER_BUF_SIZE);
+    tokio::spawn(async move {
+        let mut read_buf = [0u8; CONVERTER_BUF_SIZE];
+        loop {
+            let proxy_read = management_channel_in.read(&mut read_buf);
+            pin_mut!(proxy_read);
+
+            match futures::future::select(framed_transport.next(), proxy_read).await {
+                futures::future::Either::Left((Some(Ok(bytes)), _)) => {
+                    if management_channel_in.write_all(&bytes).await.is_err() {
+                        break;
+                    }
+                }
+                futures::future::Either::Right((Ok(num_bytes), _)) => {
+                    if framed_transport
+                        .send(read_buf[..num_bytes].to_vec().into())
+                        .await
+                        .is_err()
+                    {
+                        break;
+                    }
+                    if num_bytes == 0 {
+                        log::trace!("Mullvad daemon connection EOF");
+                        break;
+                    }
+                }
+                futures::future::Either::Right((Err(_), _)) => {
+                    let _ = framed_transport.send(bytes::Bytes::new()).await;
+                    break;
+                }
+                _ => break,
+            }
+        }
+    });
+
+    log::debug!("Mullvad daemon: connecting");
+    let channel = tonic::transport::Endpoint::from_static("serial://placeholder")
+        .connect_with_connector(DummyService(Some(management_channel_out)))
+        .await
+        .unwrap();
+    log::debug!("Mullvad daemon: connected");
+
+    ManagementServiceClient::new(channel)
+}

--- a/test-manager/src/tests/mod.rs
+++ b/test-manager/src/tests/mod.rs
@@ -118,11 +118,7 @@ pub async fn test_app_upgrade(rpc: ServiceClient) -> Result<(), Error> {
 }
 
 async fn get_package_desc(rpc: &ServiceClient, name: &str) -> Result<Package, Error> {
-    match rpc
-        .get_os(context::current())
-        .await
-        .map_err(Error::Rpc)?
-    {
+    match rpc.get_os(context::current()).await.map_err(Error::Rpc)? {
         meta::Os::Linux => Ok(Package {
             r#type: PackageType::Dpkg,
             path: Path::new(&format!("/opt/testing/{}.deb", name)).to_path_buf(),

--- a/test-rpc/Cargo.toml
+++ b/test-rpc/Cargo.toml
@@ -6,6 +6,16 @@ description = "Supports IPC between test-runner and test-manager"
 
 [dependencies]
 futures = "0.3"
+tokio = { version = "1.0", features = ["macros", "rt", "process", "time", "fs", "io-util", "rt-multi-thread"] }
 tarpc = { version = "0.30", features = ["tokio1", "serde-transport", "serde1"] }
 serde = "*"
+tokio-serde = { version = "*", features = ["json"] }
+serde_json = "*"
+bytes = "*"
 err-derive = "0.3.1"
+log = "0.4.17"
+
+[dependencies.tokio-util]
+version = "0.7"
+features = ["codec"]
+default-features = false

--- a/test-rpc/src/lib.rs
+++ b/test-rpc/src/lib.rs
@@ -1,7 +1,8 @@
+pub mod logging;
 pub mod meta;
 pub mod mullvad_daemon;
 pub mod package;
-pub mod logging;
+pub mod transport;
 
 #[tarpc::service]
 pub trait Service {

--- a/test-rpc/src/logging.rs
+++ b/test-rpc/src/logging.rs
@@ -14,4 +14,3 @@ impl std::fmt::Display for Output {
         }
     }
 }
-

--- a/test-rpc/src/mullvad_daemon.rs
+++ b/test-rpc/src/mullvad_daemon.rs
@@ -1,5 +1,10 @@
 use serde::{Deserialize, Serialize};
 
+#[cfg(any(target_os = "linux", target_os = "macos"))]
+pub const SOCKET_PATH: &str = "/var/run/mullvad-vpn";
+#[cfg(windows)]
+pub const SOCKET_PATH: &str = "//./pipe/Mullvad VPN";
+
 #[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub enum Error {
     ConnectError,

--- a/test-rpc/src/transport.rs
+++ b/test-rpc/src/transport.rs
@@ -1,0 +1,256 @@
+use bytes::{Buf, BufMut, Bytes, BytesMut};
+use futures::{SinkExt, StreamExt};
+use serde::{de::DeserializeOwned, Serialize};
+use std::io;
+use tarpc::{ClientMessage, Response};
+use tokio::io::{AsyncRead, AsyncWrite};
+use tokio_util::codec::{Decoder, Encoder, LengthDelimitedCodec};
+
+use crate::{ServiceRequest, ServiceResponse};
+
+const FRAME_TYPE_SIZE: usize = std::mem::size_of::<FrameType>();
+const DAEMON_CHANNEL_BUF_SIZE: usize = 16 * 1024;
+
+pub enum Frame {
+    TestRunner(Bytes),
+    DaemonRpc(Bytes),
+}
+
+#[repr(u8)]
+enum FrameType {
+    TestRunner,
+    DaemonRpc,
+}
+
+impl TryFrom<u8> for FrameType {
+    type Error = ();
+
+    fn try_from(value: u8) -> Result<Self, Self::Error> {
+        match value {
+            i if i == FrameType::TestRunner as u8 => Ok(FrameType::TestRunner),
+            i if i == FrameType::DaemonRpc as u8 => Ok(FrameType::DaemonRpc),
+            _ => Err(()),
+        }
+    }
+}
+
+pub type GrpcForwarder = tokio::io::DuplexStream;
+pub type CompletionHandle = tokio::task::JoinHandle<()>;
+
+pub fn create_server_transports(
+    serial_stream: impl AsyncRead + AsyncWrite + Unpin + Send + 'static,
+) -> (
+    tarpc::transport::channel::UnboundedChannel<
+        ClientMessage<ServiceRequest>,
+        Response<ServiceResponse>,
+    >,
+    GrpcForwarder,
+    CompletionHandle,
+) {
+    let (runner_forwarder_1, runner_forwarder_2) = tarpc::transport::channel::unbounded();
+
+    let (daemon_rx, mullvad_daemon_forwarder) = tokio::io::duplex(DAEMON_CHANNEL_BUF_SIZE);
+
+    let completion_handle = tokio::spawn(async move {
+        if let Err(error) =
+            forward_messages(serial_stream, runner_forwarder_2, mullvad_daemon_forwarder).await
+        {
+            log::error!("forward_messages stopped due an error: {}", error);
+        } else {
+            log::trace!("forward_messages stopped");
+        }
+    });
+
+    (runner_forwarder_1, daemon_rx, completion_handle)
+}
+
+pub fn create_client_transports(
+    serial_stream: impl AsyncRead + AsyncWrite + Unpin + Send + 'static,
+) -> (
+    tarpc::transport::channel::UnboundedChannel<
+        Response<ServiceResponse>,
+        ClientMessage<ServiceRequest>,
+    >,
+    GrpcForwarder,
+    CompletionHandle,
+) {
+    let (runner_forwarder_1, runner_forwarder_2) = tarpc::transport::channel::unbounded();
+
+    let (daemon_rx, mullvad_daemon_forwarder) = tokio::io::duplex(DAEMON_CHANNEL_BUF_SIZE);
+
+    let completion_handle = tokio::spawn(async move {
+        if let Err(error) =
+            forward_messages(serial_stream, runner_forwarder_1, mullvad_daemon_forwarder).await
+        {
+            log::error!("forward_messages stopped due an error: {}", error);
+        } else {
+            log::trace!("forward_messages stopped");
+        }
+    });
+    (runner_forwarder_2, daemon_rx, completion_handle)
+}
+
+#[derive(err_derive::Error, Debug)]
+#[error(no_from)]
+enum ForwardError {
+    #[error(display = "Failed to deserialize JSON data")]
+    DeserializeFailed(#[error(source)] serde_json::Error),
+
+    #[error(display = "Failed to serialize JSON data")]
+    SerializeFailed(#[error(source)] serde_json::Error),
+
+    #[error(display = "Serial connection error")]
+    SerialConnection(#[error(source)] io::Error),
+
+    #[error(display = "Test runner channel error")]
+    TestRunnerChannel(#[error(source)] tarpc::transport::channel::ChannelError),
+
+    #[error(display = "Daemon channel error")]
+    DaemonChannel(#[error(source)] io::Error),
+}
+
+async fn forward_messages<
+    T: Serialize + Unpin + Send + 'static,
+    S: DeserializeOwned + Unpin + Send + 'static,
+>(
+    serial_stream: impl AsyncRead + AsyncWrite + Unpin + Send + 'static,
+    mut runner_forwarder: tarpc::transport::channel::UnboundedChannel<T, S>,
+    mullvad_daemon_forwarder: GrpcForwarder,
+) -> Result<(), ForwardError> {
+    let codec = MultiplexCodec::default();
+    let mut serial_stream = codec.framed(serial_stream);
+
+    // Needs to be framed to allow empty messages.
+    let mut mullvad_daemon_forwarder = LengthDelimitedCodec::new().framed(mullvad_daemon_forwarder);
+
+    loop {
+        match futures::future::select(
+            serial_stream.next(),
+            futures::future::select(runner_forwarder.next(), mullvad_daemon_forwarder.next()),
+        )
+        .await
+        {
+            futures::future::Either::Left((Some(frame), _)) => {
+                let frame = frame.map_err(ForwardError::SerialConnection)?;
+
+                //
+                // Deserialize frame and send it to one of the channels
+                //
+
+                match frame {
+                    Frame::TestRunner(data) => {
+                        let message = serde_json::from_slice(&data)
+                            .map_err(ForwardError::DeserializeFailed)?;
+                        runner_forwarder
+                            .send(message)
+                            .await
+                            .map_err(ForwardError::TestRunnerChannel)?;
+                    }
+                    Frame::DaemonRpc(data) => {
+                        mullvad_daemon_forwarder
+                            .send(data)
+                            .await
+                            .map_err(|error| ForwardError::DaemonChannel(error))?;
+                    }
+                }
+            }
+            futures::future::Either::Right((
+                futures::future::Either::Left((Some(message), _)),
+                _,
+            )) => {
+                let message = message.map_err(ForwardError::TestRunnerChannel)?;
+
+                //
+                // Serialize messages from tarpc channel into frames
+                // and send them over the serial connection
+                //
+
+                let serialized =
+                    serde_json::to_vec(&message).map_err(ForwardError::SerializeFailed)?;
+                serial_stream
+                    .send(Frame::TestRunner(serialized.into()))
+                    .await
+                    .map_err(ForwardError::SerialConnection)?;
+            }
+            futures::future::Either::Right((
+                futures::future::Either::Right((Some(data), _)),
+                _,
+            )) => {
+                let data = data.map_err(ForwardError::DaemonChannel)?;
+
+                //
+                // Forward whatever the heck this is
+                //
+
+                serial_stream
+                    .send(Frame::DaemonRpc(data.into()))
+                    .await
+                    .map_err(ForwardError::SerialConnection)?;
+            }
+            futures::future::Either::Left((None, _))
+            | futures::future::Either::Right((futures::future::Either::Left((None, _)), _)) => {
+                break Ok(());
+            }
+            futures::future::Either::Right((futures::future::Either::Right((None, _)), _)) => {
+                //
+                // Force management interface socket to close
+                //
+                let _ = serial_stream.send(Frame::DaemonRpc(Bytes::new())).await;
+
+                break Ok(());
+            }
+        }
+    }
+}
+
+#[derive(Default, Debug, Clone)]
+pub struct MultiplexCodec {
+    len_delim_codec: LengthDelimitedCodec,
+}
+
+impl MultiplexCodec {
+    fn decode_frame(mut frame: BytesMut) -> Result<Frame, io::Error> {
+        if frame.len() < FRAME_TYPE_SIZE {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "frame does not contain frame type",
+            ));
+        }
+
+        let mut type_bytes = frame.split_to(FRAME_TYPE_SIZE);
+        let frame_type = FrameType::try_from(type_bytes.get_u8())
+            .map_err(|_err| io::Error::new(io::ErrorKind::InvalidInput, "invalid frame type"))?;
+
+        match frame_type {
+            FrameType::TestRunner => Ok(Frame::TestRunner(frame.into())),
+            FrameType::DaemonRpc => Ok(Frame::DaemonRpc(frame.into())),
+        }
+    }
+}
+
+impl Decoder for MultiplexCodec {
+    type Item = Frame;
+    type Error = io::Error;
+
+    fn decode(&mut self, src: &mut BytesMut) -> Result<Option<Self::Item>, Self::Error> {
+        let frame = self.len_delim_codec.decode(src)?;
+        frame.map(Self::decode_frame).transpose()
+    }
+}
+
+impl Encoder<Frame> for MultiplexCodec {
+    type Error = io::Error;
+
+    fn encode(&mut self, frame: Frame, dst: &mut BytesMut) -> Result<(), Self::Error> {
+        let (bytes, frame_type) = match frame {
+            Frame::TestRunner(bytes) => (bytes, FrameType::TestRunner as u8),
+            Frame::DaemonRpc(bytes) => (bytes, FrameType::DaemonRpc as u8),
+        };
+        // TODO: implement without copying
+        let mut buffer = BytesMut::new();
+        buffer.reserve(bytes.len() + FRAME_TYPE_SIZE);
+        buffer.put_u8(frame_type);
+        buffer.put(&bytes[..]);
+        self.len_delim_codec.encode(buffer.into(), dst)
+    }
+}

--- a/test-runner/Cargo.toml
+++ b/test-runner/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2021"
 
 [dependencies]
 futures = "0.3"
+bytes = "*"
 tarpc = { version = "0.30", features = ["tokio1", "serde-transport", "serde1"] }
 tokio = { version = "1.0", features = ["macros", "rt", "process", "time", "fs", "io-util", "rt-multi-thread"] }
 tokio-serial = "5.4.1"
@@ -12,10 +13,11 @@ tokio-serde = { version = "*", features = ["json"] }
 err-derive = "0.3.1"
 log = "0.4.17"
 lazy_static = "1.4.0"
+serde = { version = "1.0" }
+serde_json = "1.0"
+parity-tokio-ipc = "0.9"
 
 test-rpc = { path = "../test-rpc" }
-
-env_logger = "0.9"
 
 [dependencies.tokio-util]
 version = "0.7"

--- a/test-runner/src/logging.rs
+++ b/test-runner/src/logging.rs
@@ -35,7 +35,7 @@ impl log::Log for StdOutBuffer {
                             .send(Output::StdErr(format!("{}", record.args())))
                             .unwrap();
                     }
-                },
+                }
                 _ => (),
             }
             println!("{}", record.args());

--- a/test-runner/src/main.rs
+++ b/test-runner/src/main.rs
@@ -1,16 +1,20 @@
+use futures::{pin_mut, SinkExt, StreamExt};
+use logging::LOGGER;
 use tarpc::context;
 use tarpc::server::Channel;
 use test_rpc::{
     meta,
+    mullvad_daemon::SOCKET_PATH,
     package::{InstallResult, Package},
+    transport::GrpcForwarder,
     Service,
 };
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio_util::codec::{Decoder, LengthDelimitedCodec};
-use logging::LOGGER;
 
+mod logging;
 mod mullvad_daemon;
 mod package;
-mod logging;
 
 #[derive(Clone)]
 pub struct TestServer(pub ());
@@ -96,16 +100,110 @@ async fn main() -> Result<(), Error> {
 
     log::info!("Connecting to {}", path);
 
-    let conn = tokio_serial::SerialStream::open(&tokio_serial::new(path, BAUD)).unwrap();
-
-    let codec = LengthDelimitedCodec::new();
-    let framed = codec.framed(conn);
+    let serial_stream = tokio_serial::SerialStream::open(&tokio_serial::new(path, BAUD)).unwrap();
+    let (runner_transport, mullvad_daemon_transport, _completion_handle) =
+        test_rpc::transport::create_server_transports(serial_stream);
 
     log::info!("Running server");
 
-    let transport = tarpc::serde_transport::new(framed, tokio_serde::formats::Json::default());
-    let server = tarpc::server::BaseChannel::with_defaults(transport);
+    tokio::spawn(foward_to_mullvad_daemon_interface(mullvad_daemon_transport));
+
+    let server = tarpc::server::BaseChannel::with_defaults(runner_transport);
     server.execute(TestServer(()).serve()).await;
 
     Ok(())
+}
+
+/// Forward data between the test manager and Mullvad management interface socket
+async fn foward_to_mullvad_daemon_interface(proxy_transport: GrpcForwarder) {
+    const IPC_READ_BUF_SIZE: usize = 16 * 1024;
+
+    let mut srv_read_buf = [0u8; IPC_READ_BUF_SIZE];
+    let mut proxy_transport = LengthDelimitedCodec::new().framed(proxy_transport);
+
+    loop {
+        // Wait for input from the test manager before connecting to the UDS or named pipe.
+        // Connect at the last moment since the daemon may not even be running when the
+        // test runner first starts.
+        let first_message = match proxy_transport.next().await {
+            Some(Ok(bytes)) => {
+                if bytes.len() == 0 {
+                    log::debug!("ignoring EOF from client");
+                    continue;
+                }
+                bytes
+            }
+            Some(Err(error)) => {
+                log::error!("daemon client channel error: {error}");
+                break;
+            }
+            None => break,
+        };
+
+        log::info!("mullvad daemon: connecting");
+
+        let mut daemon_socket_endpoint =
+            match parity_tokio_ipc::Endpoint::connect(SOCKET_PATH).await {
+                Ok(uds_endpoint) => uds_endpoint,
+                Err(error) => {
+                    log::error!("mullvad daemon: failed to connect: {error}");
+                    // send EOF
+                    let _ = proxy_transport.send(bytes::Bytes::new());
+                    continue;
+                }
+            };
+
+        log::info!("mullvad daemon: connected");
+
+        if let Err(error) = daemon_socket_endpoint.write_all(&first_message).await {
+            log::error!("writing to uds failed: {error}");
+            continue;
+        }
+
+        loop {
+            let srv_read = daemon_socket_endpoint.read(&mut srv_read_buf);
+            pin_mut!(srv_read);
+
+            match futures::future::select(srv_read, proxy_transport.next()).await {
+                futures::future::Either::Left((read, _)) => match read {
+                    Ok(num_bytes) => {
+                        if num_bytes == 0 {
+                            log::debug!("uds EOF; restarting server");
+                            break;
+                        }
+                        if let Err(error) = proxy_transport
+                            .send(srv_read_buf[..num_bytes].to_vec().into())
+                            .await
+                        {
+                            log::error!("writing to client channel failed: {error}");
+                            break;
+                        }
+                    }
+                    Err(error) => {
+                        log::error!("reading from uds failed: {error}");
+                        break;
+                    }
+                },
+                futures::future::Either::Right((read, _)) => match read {
+                    Some(Ok(bytes)) => {
+                        if bytes.len() == 0 {
+                            log::debug!("management interface EOF; restarting server");
+                            break;
+                        }
+                        if let Err(error) = daemon_socket_endpoint.write_all(&bytes).await {
+                            log::error!("writing to uds failed: {error}");
+                            break;
+                        }
+                    }
+                    Some(Err(error)) => {
+                        log::error!("daemon client channel error: {error}");
+                        break;
+                    }
+                    None => break,
+                },
+            }
+        }
+
+        log::info!("mullvad daemon: disconnected");
+    }
 }

--- a/test-runner/src/mullvad_daemon.rs
+++ b/test-runner/src/mullvad_daemon.rs
@@ -1,11 +1,6 @@
 use std::path::Path;
-use test_rpc::mullvad_daemon::{Error, Result, ServiceStatus};
+use test_rpc::mullvad_daemon::{Error, Result, ServiceStatus, SOCKET_PATH};
 use tokio::process::Command;
-
-#[cfg(any(target_os = "linux", target_os = "macos"))]
-const SOCKET_PATH: &str = "/var/run/mullvad-vpn";
-#[cfg(windows)]
-const SOCKET_PATH: &str = "//./pipe/Mullvad VPN";
 
 #[cfg(any(target_os = "linux", target_os = "macos"))]
 const MULLVAD_BIN: &str = "mullvad";


### PR DESCRIPTION
This PR adds frame types to the serial stream. Adding them allowed me to add a frame type that gives the test manager immediate access to the Mullvad daemon's UDS/named pipe in the guest. This makes test writing more ergonomic, as there's no longer a need to duplicate the daemon interface in the tarpc interface.