### PR TITLE
Simplify launching the test environment

### DIFF
--- a/launch-guest.sh
+++ b/launch-guest.sh
@@ -9,11 +9,13 @@ export TARGET=${TARGET:-"x86_64-unknown-linux-gnu"}
 case $TARGET in
 
     "x86_64-unknown-linux-gnu")
+        SERIAL_PORT=serial_port_linux
         OSIMAGE=./os-images/debian.qcow2
         RUNNERIMAGE=./testrunner-images/linux-test-runner.img
         ;;
 
     "x86_64-pc-windows-gnu")
+        SERIAL_PORT=serial_port_windows
         OSIMAGE=./os-images/windows10.qcow2
         RUNNERIMAGE=./testrunner-images/windows-test-runner.img
         ;;
@@ -34,7 +36,18 @@ case $TARGET in
 
 esac
 
-sudo ./scripts/setup-network.sh
+# Check if we need to setup the network
+ip link show br-mullvadtest >&/dev/null && sudo ./scripts/setup-network.sh
+
+pty=$(python3 -<<END_SCRIPT
+import os
+master, slave = os.openpty()
+print(os.ttyname(slave))
+END_SCRIPT
+)
+
+trap "rm -f $SERIAL_PORT" EXIT
+ln -s $pty $SERIAL_PORT
 
 sudo qemu-system-x86_64 -cpu host -accel kvm -m 2048 -smp 2 \
     -snapshot \
@@ -44,4 +57,3 @@ sudo qemu-system-x86_64 -cpu host -accel kvm -m 2048 -smp 2 \
     -device usb-storage,drive=runner,bus=xhci.0 \
     -device virtio-serial-pci -serial pty \
     -nic tap,ifname=tap-mullvadtest,script=no,downscript=no
-

--- a/runtests.sh
+++ b/runtests.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+
+set -eu
+
+export TARGET=${TARGET:-"x86_64-unknown-linux-gnu"}
+
+serial_port=serial_port_linux
+
+case $TARGET in
+    "x86_64-unknown-linux-gnu")
+        serial_port=serial_port_linux
+        ;;
+
+    "x86_64-pc-windows-gnu")
+        serial_port=serial_port_windows
+        ;;
+
+    *-darwin)
+        echo "Not yet supported"
+        exit 1
+        ;;
+
+    *)
+        echo "Unknown target: $TARGET"
+        exit 1
+        ;;
+esac
+
+if [[ -n ${1+x} ]]; then
+    case $1 in
+        "linux")
+            serial_port=serial_port_linux
+            shift
+            ;;
+
+        "windows")
+            serial_port=serial_port_windows
+            shift
+            ;;
+        "mac")
+            echo "Mac is not yet supported"
+            exit 1
+            ;;
+        *);;
+    esac
+fi
+
+cargo build -p test-manager
+sudo ./target/debug/test-manager $serial_port $@


### PR DESCRIPTION
Automatically create a symbolic link for the serial port, automatically provide this to the test manager when launching with a new script `runtests.sh`