### PR TITLE
Let multiple tests be specified

### DIFF
--- a/test-manager/src/logging.rs
+++ b/test-manager/src/logging.rs
@@ -65,12 +65,9 @@ where
         match output_after_test {
             Ok(mut output_after_test) => {
                 output.append(&mut output_after_test);
-                for output in output_after_test {
-                    println!("{}", output);
-                }
             }
             Err(e) => {
-                output.push(Output::Other(format!("could not get logs due to: {:?}", e)));
+                output.push(Output::Other(format!("could not get logs: {:?}", e)));
             }
         }
     }


### PR DESCRIPTION
Also, remove the duplicate test output logging. It now also checks if the arguments are substrings of the test names instead of matching against exact names.