### PR TITLE
Support old Mullvad management clients

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -458,6 +458,12 @@ dependencies = [
 
 [[package]]
 name = "fixedbitset"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37ab347416e802de484e4d03c7316c48f1ecb56574dfd4a46a80f173ce1de04d"
+
+[[package]]
+name = "fixedbitset"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
@@ -610,7 +616,7 @@ dependencies = [
  "indexmap",
  "slab",
  "tokio",
- "tokio-util",
+ "tokio-util 0.7.4",
  "tracing",
 ]
 
@@ -619,6 +625,15 @@ name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+
+[[package]]
+name = "heck"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
+dependencies = [
+ "unicode-segmentation",
+]
 
 [[package]]
 name = "heck"
@@ -837,7 +852,7 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "002f4dfe6d97ae88c33f3489c0d31ffc6f81d9a492de98ff113b127d73bafff8"
 dependencies = [
- "heck",
+ "heck 0.4.0",
  "proc-macro2",
  "quote",
  "syn",
@@ -981,22 +996,57 @@ dependencies = [
  "futures",
  "lazy_static",
  "log",
- "mullvad-paths",
- "mullvad-types",
+ "mullvad-paths 0.0.0",
+ "mullvad-types 0.0.0",
  "nix 0.23.1",
  "parity-tokio-ipc",
- "prost",
- "prost-types",
- "talpid-types",
+ "prost 0.11.2",
+ "prost-types 0.11.2",
+ "talpid-types 0.0.0",
  "tokio",
- "tonic",
- "tonic-build",
+ "tonic 0.8.2",
+ "tonic-build 0.8.2",
+ "tower",
+]
+
+[[package]]
+name = "mullvad-management-interface"
+version = "0.1.0"
+source = "git+https://github.com/mullvad/mullvadvpn-app?rev=2022.5#5bcd2533633d76b1deaf5875b24a2c83bec6fc49"
+dependencies = [
+ "chrono",
+ "err-derive",
+ "futures",
+ "lazy_static",
+ "log",
+ "mullvad-paths 0.1.0",
+ "mullvad-types 0.1.0",
+ "nix 0.23.1",
+ "parity-tokio-ipc",
+ "prost 0.8.0",
+ "prost-types 0.8.0",
+ "talpid-types 0.1.0",
+ "tokio",
+ "tonic 0.5.2",
+ "tonic-build 0.5.2",
  "tower",
 ]
 
 [[package]]
 name = "mullvad-paths"
 version = "0.0.0"
+dependencies = [
+ "dirs-next",
+ "err-derive",
+ "log",
+ "widestring",
+ "windows-sys 0.42.0",
+]
+
+[[package]]
+name = "mullvad-paths"
+version = "0.1.0"
+source = "git+https://github.com/mullvad/mullvadvpn-app?rev=2022.5#5bcd2533633d76b1deaf5875b24a2c83bec6fc49"
 dependencies = [
  "dirs-next",
  "err-derive",
@@ -1016,7 +1066,24 @@ dependencies = [
  "rand 0.8.5",
  "regex",
  "serde",
- "talpid-types",
+ "talpid-types 0.0.0",
+]
+
+[[package]]
+name = "mullvad-types"
+version = "0.1.0"
+source = "git+https://github.com/mullvad/mullvadvpn-app?rev=2022.5#5bcd2533633d76b1deaf5875b24a2c83bec6fc49"
+dependencies = [
+ "chrono",
+ "err-derive",
+ "ipnetwork",
+ "jnix",
+ "lazy_static",
+ "log",
+ "rand 0.8.5",
+ "regex",
+ "serde",
+ "talpid-types 0.1.0",
 ]
 
 [[package]]
@@ -1201,11 +1268,21 @@ checksum = "478c572c3d73181ff3c2539045f6eb99e5491218eae919370993b890cdbdd98e"
 
 [[package]]
 name = "petgraph"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "467d164a6de56270bd7c4d070df81d07beace25012d5103ced4e9ff08d6afdb7"
+dependencies = [
+ "fixedbitset 0.2.0",
+ "indexmap",
+]
+
+[[package]]
+name = "petgraph"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6d5014253a1331579ce62aa67443b4a658c5e7dd03d4bc6d302b94474888143"
 dependencies = [
- "fixedbitset",
+ "fixedbitset 0.4.2",
  "indexmap",
 ]
 
@@ -1334,12 +1411,40 @@ dependencies = [
 
 [[package]]
 name = "prost"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de5e2533f59d08fcf364fd374ebda0692a70bd6d7e66ef97f306f45c6c5d8020"
+dependencies = [
+ "bytes",
+ "prost-derive 0.8.0",
+]
+
+[[package]]
+name = "prost"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a0841812012b2d4a6145fae9a6af1534873c32aa67fff26bd09f8fa42c83f95a"
 dependencies = [
  "bytes",
- "prost-derive",
+ "prost-derive 0.11.2",
+]
+
+[[package]]
+name = "prost-build"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "355f634b43cdd80724ee7848f95770e7e70eefa6dcf14fea676216573b8fd603"
+dependencies = [
+ "bytes",
+ "heck 0.3.3",
+ "itertools",
+ "log",
+ "multimap",
+ "petgraph 0.5.1",
+ "prost 0.8.0",
+ "prost-types 0.8.0",
+ "tempfile",
+ "which",
 ]
 
 [[package]]
@@ -1349,19 +1454,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d8b442418ea0822409d9e7d047cbf1e7e9e1760b172bf9982cf29d517c93511"
 dependencies = [
  "bytes",
- "heck",
+ "heck 0.4.0",
  "itertools",
  "lazy_static",
  "log",
  "multimap",
- "petgraph",
+ "petgraph 0.6.2",
  "prettyplease",
- "prost",
- "prost-types",
+ "prost 0.11.2",
+ "prost-types 0.11.2",
  "regex",
  "syn",
  "tempfile",
  "which",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "600d2f334aa05acb02a755e217ef1ab6dea4d51b58b7846588b747edec04efba"
+dependencies = [
+ "anyhow",
+ "itertools",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1379,12 +1497,22 @@ dependencies = [
 
 [[package]]
 name = "prost-types"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "603bbd6394701d13f3f25aada59c7de9d35a6a5887cfc156181234a44002771b"
+dependencies = [
+ "bytes",
+ "prost 0.8.0",
+]
+
+[[package]]
+name = "prost-types"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "747761bc3dc48f9a34553bf65605cf6cb6288ba219f3450b4275dbd81539551a"
 dependencies = [
  "bytes",
- "prost",
+ "prost 0.11.2",
 ]
 
 [[package]]
@@ -1812,6 +1940,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "talpid-types"
+version = "0.1.0"
+source = "git+https://github.com/mullvad/mullvadvpn-app?rev=2022.5#5bcd2533633d76b1deaf5875b24a2c83bec6fc49"
+dependencies = [
+ "base64",
+ "err-derive",
+ "ipnetwork",
+ "jnix",
+ "rand 0.8.5",
+ "serde",
+ "x25519-dalek",
+ "zeroize",
+]
+
+[[package]]
 name = "talpid-windows-net"
 version = "0.0.0"
 dependencies = [
@@ -1842,7 +1985,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "tokio-serde",
- "tokio-util",
+ "tokio-util 0.7.4",
  "tracing",
  "tracing-opentelemetry",
 ]
@@ -1891,20 +2034,21 @@ dependencies = [
  "err-derive",
  "futures",
  "log",
- "mullvad-management-interface",
- "mullvad-types",
+ "mullvad-management-interface 0.0.0",
+ "mullvad-management-interface 0.1.0",
+ "mullvad-types 0.0.0",
  "pcap",
  "pnet_packet",
  "serde",
- "talpid-types",
+ "talpid-types 0.0.0",
  "tarpc",
  "test-rpc",
  "test_macro",
  "tokio",
  "tokio-serde",
  "tokio-serial",
- "tokio-util",
- "tonic",
+ "tokio-util 0.7.4",
+ "tonic 0.8.2",
  "tower",
 ]
 
@@ -1922,7 +2066,7 @@ dependencies = [
  "tarpc",
  "tokio",
  "tokio-serde",
- "tokio-util",
+ "tokio-util 0.7.4",
 ]
 
 [[package]]
@@ -1936,7 +2080,7 @@ dependencies = [
  "hyper-rustls",
  "lazy_static",
  "log",
- "mullvad-management-interface",
+ "mullvad-management-interface 0.0.0",
  "parity-tokio-ipc",
  "rustls-pemfile 0.2.1",
  "serde",
@@ -1948,7 +2092,7 @@ dependencies = [
  "tokio-rustls",
  "tokio-serde",
  "tokio-serial",
- "tokio-util",
+ "tokio-util 0.7.4",
 ]
 
 [[package]]
@@ -1959,6 +2103,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+ "test-rpc",
 ]
 
 [[package]]
@@ -2093,6 +2238,20 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
+version = "0.6.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36943ee01a6d67977dd3f84a5a1d2efeb4ada3a1ae771cadfaa535d9d9fc6507"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "log",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-util"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bb2e075f03b3d66d8d8785356224ba688d2906a371015e225beeb65ca92c740"
@@ -2104,6 +2263,37 @@ dependencies = [
  "slab",
  "tokio",
  "tracing",
+]
+
+[[package]]
+name = "tonic"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "796c5e1cd49905e65dd8e700d4cb1dffcbfdb4fc9d017de08c1a537afd83627c"
+dependencies = [
+ "async-stream",
+ "async-trait",
+ "base64",
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http",
+ "http-body",
+ "hyper",
+ "hyper-timeout",
+ "percent-encoding",
+ "pin-project",
+ "prost 0.8.0",
+ "prost-derive 0.8.0",
+ "tokio",
+ "tokio-stream",
+ "tokio-util 0.6.10",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+ "tracing-futures",
 ]
 
 [[package]]
@@ -2126,16 +2316,28 @@ dependencies = [
  "hyper-timeout",
  "percent-encoding",
  "pin-project",
- "prost",
- "prost-derive",
+ "prost 0.11.2",
+ "prost-derive 0.11.2",
  "tokio",
  "tokio-stream",
- "tokio-util",
+ "tokio-util 0.7.4",
  "tower",
  "tower-layer",
  "tower-service",
  "tracing",
  "tracing-futures",
+]
+
+[[package]]
+name = "tonic-build"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12b52d07035516c2b74337d2ac7746075e7dcae7643816c1b12c5ff8a7484c08"
+dependencies = [
+ "proc-macro2",
+ "prost-build 0.8.0",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -2146,7 +2348,7 @@ checksum = "48c6fd7c2581e36d63388a9e04c350c21beb7a8b059580b2e93993c526899ddc"
 dependencies = [
  "prettyplease",
  "proc-macro2",
- "prost-build",
+ "prost-build 0.11.2",
  "quote",
  "syn",
 ]
@@ -2165,7 +2367,7 @@ dependencies = [
  "rand 0.8.5",
  "slab",
  "tokio",
- "tokio-util",
+ "tokio-util 0.7.4",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -2447,6 +2649,12 @@ dependencies = [
  "libc",
  "once_cell",
 ]
+
+[[package]]
+name = "widestring"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "653f141f39ec16bba3c5abe400a0c60da7468261cc2cbf36805022876bc721a8"
 
 [[package]]
 name = "winapi"

--- a/test-manager/Cargo.toml
+++ b/test-manager/Cargo.toml
@@ -28,8 +28,11 @@ env_logger = "0.9"
 
 tonic = "0.8"
 tower = "0.4"
-mullvad-management-interface = { path = "../../mullvadvpn-app/mullvad-management-interface" }
 colored = "2.0.0"
+
+# TODO: inject management interface versions
+mullvad-management-interface = { path = "../../mullvadvpn-app/mullvad-management-interface" }
+old-mullvad-management-interface = { package = "mullvad-management-interface", git = "https://github.com/mullvad/mullvadvpn-app", rev = "2022.5" }
 
 [dependencies.tokio-util]
 version = "0.7"

--- a/test-manager/src/logging.rs
+++ b/test-manager/src/logging.rs
@@ -1,7 +1,6 @@
 use crate::tests::Error;
 use colored::Colorize;
 use futures::FutureExt;
-use mullvad_management_interface::ManagementServiceClient;
 use std::future::Future;
 use std::panic;
 use tarpc::context;
@@ -60,14 +59,14 @@ impl TestOutput {
     }
 }
 
-pub async fn run_test<F, R>(
+pub async fn run_test<F, R, MullvadClient>(
     runner_rpc: ServiceClient,
-    mullvad_rpc: ManagementServiceClient,
+    mullvad_rpc: MullvadClient,
     test: F,
     test_name: &'static str,
 ) -> Result<TestOutput, Error>
 where
-    F: Fn(ServiceClient, ManagementServiceClient) -> R,
+    F: Fn(ServiceClient, MullvadClient) -> R,
     R: Future<Output = Result<(), Error>>,
 {
     let _flushed = runner_rpc.try_poll_output(context::current()).await;

--- a/test-manager/src/main.rs
+++ b/test-manager/src/main.rs
@@ -58,7 +58,7 @@ async fn main() -> Result<(), Error> {
     }
 
     for test in tests {
-        let mclient = mullvad_client.client().await;
+        let mclient = mullvad_client.from_type(test.mullvad_client_version).await;
 
         log::info!("Running {}", test.name);
         let test_result = run_test(client.clone(), mclient, test.func, test.name)

--- a/test-manager/src/tests/mod.rs
+++ b/test-manager/src/tests/mod.rs
@@ -69,10 +69,7 @@ pub mod manager_tests {
     }
 
     #[manager_test(priority = -5)]
-    pub async fn test_install_previous_app(
-        rpc: ServiceClient,
-        _mullvad_client: ManagementServiceClient,
-    ) -> Result<(), Error> {
+    pub async fn test_install_previous_app(rpc: ServiceClient) -> Result<(), Error> {
         // verify that daemon is not already running
         if rpc.mullvad_daemon_get_status(context::current()).await? != ServiceStatus::NotRunning {
             return Err(Error::DaemonRunning);
@@ -95,10 +92,7 @@ pub mod manager_tests {
     }
 
     #[manager_test(priority = -4)]
-    pub async fn test_upgrade_app(
-        rpc: ServiceClient,
-        _mullvad_client: ManagementServiceClient,
-    ) -> Result<(), Error> {
+    pub async fn test_upgrade_app(rpc: ServiceClient) -> Result<(), Error> {
         // verify that daemon is running
         if rpc.mullvad_daemon_get_status(context::current()).await? != ServiceStatus::Running {
             return Err(Error::DaemonNotRunning);
@@ -126,10 +120,7 @@ pub mod manager_tests {
     }
 
     #[manager_test(priority = -3)]
-    pub async fn test_uninstall_app(
-        rpc: ServiceClient,
-        _mullvad_client: ManagementServiceClient,
-    ) -> Result<(), Error> {
+    pub async fn test_uninstall_app(rpc: ServiceClient) -> Result<(), Error> {
         // FIXME: Make it possible to perform a complete silent uninstall on Windows.
         //        Or interact with dialogs.
 
@@ -158,10 +149,7 @@ pub mod manager_tests {
     }
 
     #[manager_test(priority = -2)]
-    pub async fn test_install_new_app(
-        rpc: ServiceClient,
-        _mullvad_client: ManagementServiceClient,
-    ) -> Result<(), Error> {
+    pub async fn test_install_new_app(rpc: ServiceClient) -> Result<(), Error> {
         // verify that daemon is not already running
         if rpc.mullvad_daemon_get_status(context::current()).await? != ServiceStatus::NotRunning {
             return Err(Error::DaemonRunning);

--- a/test-manager/src/tests/test_metadata.rs
+++ b/test-manager/src/tests/test_metadata.rs
@@ -1,13 +1,12 @@
 use super::Error;
 use futures::future::BoxFuture;
-use mullvad_management_interface::ManagementServiceClient;
-use test_rpc::ServiceClient;
+use test_rpc::{mullvad_daemon::MullvadClientVersion, ServiceClient};
 
 pub struct TestMetadata {
     pub name: &'static str,
     pub command: &'static str,
-    pub func: Box<
-        dyn Fn(ServiceClient, ManagementServiceClient) -> BoxFuture<'static, Result<(), Error>>,
-    >,
+    pub mullvad_client_version: MullvadClientVersion,
+    pub func:
+        Box<dyn Fn(ServiceClient, Box<dyn std::any::Any>) -> BoxFuture<'static, Result<(), Error>>>,
     pub priority: Option<i32>,
 }

--- a/test-manager/test_macro/Cargo.toml
+++ b/test-manager/test_macro/Cargo.toml
@@ -11,3 +11,5 @@ syn = "1.0"
 quote = "1.0"
 proc-macro2 = "1.0"
 convert_case = "0.6"
+
+test-rpc = { path = "../../test-rpc" }

--- a/test-rpc/src/mullvad_daemon.rs
+++ b/test-rpc/src/mullvad_daemon.rs
@@ -20,3 +20,10 @@ pub enum ServiceStatus {
     NotRunning,
     Running,
 }
+
+#[derive(Clone, Copy)]
+pub enum MullvadClientVersion {
+    None,
+    New,
+    Previous,
+}


### PR DESCRIPTION
This PR makes it possible for tests to decide which Mullvad management interface to use. They are now able to use old versions of the interface. This is unfortunately necessary since old daemon versions are sometimes incompatible with the latest interface.