### PR TITLE
Set up unprivileged networking using namespaces and add CI script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 /os-images
 /testrunner-images
 .dnsmasq.pid
+.dnsmasq.leases

--- a/BUILD_OS_IMAGE.md
+++ b/BUILD_OS_IMAGE.md
@@ -1,5 +1,3 @@
-TODO: Automate the creation of the base image
-
 This document explains how to create base OS images and run test runners on them.
 
 For macOS, the host machine must be macOS. All other platforms assume that the host is Linux.
@@ -64,15 +62,14 @@ This can be achieved as follows:
 
 ## Bootstrapping RPC server
 
-The testing image needs to be mounted to `E:`, and the RPC server needs to be started on boot.
+The RPC server needs to be started on boot, with the test runner image mounted at `E:`.
 This can be achieved as follows:
 
-* (If needed) start the VM:
+* Restart the VM:
 
     ```
     qemu-system-x86_64 -cpu host -accel kvm -m 2048 -smp 2 \
         -drive file="./os-images/windows10.qcow2" \
-        -drive if=none,id=runner,file="./testrunner-images/windows-test-runner.img" \
         -device nec-usb-xhci,id=xhci \
         -device usb-storage,drive=runner,bus=xhci.0
     ```

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1249,6 +1249,7 @@ dependencies = [
 [[package]]
 name = "mullvad-api"
 version = "0.0.0"
+source = "git+https://github.com/mullvad/mullvadvpn-app#6efde79b1ad73f235f56c17d2753343540c3da66"
 dependencies = [
  "chrono",
  "err-derive",
@@ -1274,6 +1275,7 @@ dependencies = [
 [[package]]
 name = "mullvad-management-interface"
 version = "0.0.0"
+source = "git+https://github.com/mullvad/mullvadvpn-app#6efde79b1ad73f235f56c17d2753343540c3da66"
 dependencies = [
  "chrono",
  "err-derive",
@@ -1319,6 +1321,7 @@ dependencies = [
 [[package]]
 name = "mullvad-paths"
 version = "0.0.0"
+source = "git+https://github.com/mullvad/mullvadvpn-app#6efde79b1ad73f235f56c17d2753343540c3da66"
 dependencies = [
  "dirs-next",
  "err-derive",
@@ -1340,6 +1343,7 @@ dependencies = [
 [[package]]
 name = "mullvad-types"
 version = "0.0.0"
+source = "git+https://github.com/mullvad/mullvadvpn-app#6efde79b1ad73f235f56c17d2753343540c3da66"
 dependencies = [
  "chrono",
  "err-derive",
@@ -2392,6 +2396,7 @@ dependencies = [
 [[package]]
 name = "talpid-time"
 version = "0.0.0"
+source = "git+https://github.com/mullvad/mullvadvpn-app#6efde79b1ad73f235f56c17d2753343540c3da66"
 dependencies = [
  "libc",
  "tokio",
@@ -2400,6 +2405,7 @@ dependencies = [
 [[package]]
 name = "talpid-types"
 version = "0.0.0"
+source = "git+https://github.com/mullvad/mullvadvpn-app#6efde79b1ad73f235f56c17d2753343540c3da66"
 dependencies = [
  "base64",
  "err-derive",
@@ -2429,6 +2435,7 @@ dependencies = [
 [[package]]
 name = "talpid-windows-net"
 version = "0.0.0"
+source = "git+https://github.com/mullvad/mullvadvpn-app#6efde79b1ad73f235f56c17d2753343540c3da66"
 dependencies = [
  "err-derive",
  "futures",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -224,9 +224,9 @@ checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
 name = "bytes"
-version = "1.2.1"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec8a7b6a70fde80372154c65702f00a0f56f3e1c36abbc6c440484be248856db"
+checksum = "dfb24e866b15a1af2a1b663f10c6b6b8f397a84aadb828f12e5b289ec23a3a3c"
 
 [[package]]
 name = "cc"
@@ -2165,18 +2165,18 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.147"
+version = "1.0.148"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d193d69bae983fc11a79df82342761dfbf28a99fc8d203dca4c3c1b590948965"
+checksum = "e53f64bb4ba0191d6d0676e1b141ca55047d83b74f5607e6d8eb88126c52c2dc"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.147"
+version = "1.0.148"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f1d362ca8fc9c3e3a7484440752472d68a6caa98f1ab81d99b5dfe517cec852"
+checksum = "a55492425aa53521babf6137309e7d34c20bbfbbfcfe2c7f3a047fd1f6b92c0c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2362,9 +2362,9 @@ checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "syn"
-version = "1.0.103"
+version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a864042229133ada95abf3b54fdc62ef5ccabe9515b64717bcb9a1919e59445d"
+checksum = "4ae548ec36cf198c0ef7710d3c230987c2d6d7bd98ad6edc0274462724c585ce"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2511,6 +2511,7 @@ dependencies = [
  "mullvad-management-interface 0.0.0",
  "mullvad-management-interface 0.1.0",
  "mullvad-types 0.0.0",
+ "once_cell",
  "pcap",
  "pnet_packet",
  "serde",

--- a/README.md
+++ b/README.md
@@ -37,6 +37,13 @@ For macOS, the host machine must be macOS. All other platforms assume that the h
     dnf install mingw64-gcc mingw64-winpthreads-static mtools
     ```
 
+* `rootlesskit` is used to set up an isolated network namespace with `slirp`,
+  and `dnsmasq` to assign IPs to VMs/containers.
+
+    ```
+    dnf install golang-github-rootless-containers-rootlesskit dnsmasq
+    ```
+
 ## Building test-runner image
 
 You must get a `.deb` or `.exe` of the Mullvad App from https://releases.mullvad.net/releases/ in

--- a/README.md
+++ b/README.md
@@ -45,5 +45,20 @@ Run all tests on Debian using `./runtests.sh`. To run the tests on Windows (on a
 To run the tests on ARM64 macOS (on a *macOS* host), use
 `TARGET=aarch64-apple-darwin ./runtests.sh`.
 
-# Seeing the output
+## Environment variables
+
+* `ACCOUNT_TOKEN` - Must be set to a valid Mullvad account number since a lot of tests depend on
+  the app being logged in.
+
+* `SHOW_DISPLAY` - Setting this causes prevents the tests from running "headless". It also prevents
+  the guest VM from being killed once the tests have finished running.
+
+* `PREVIOUS_APP_FILENAME` - This should be a set to the filename of a package in `./packages/`. It
+  will be used to install the previous app version and is used for testing upgrades to the version
+  under test.
+
+* `CURRENT_APP_FILENAME` - This should be a set to the filename of a package  in `./packages/`. It
+  should contain the app version under test.
+
+## Seeing the output
 In the guest you can see the output by running `sudo journalctl -f -u testrunner`

--- a/README.md
+++ b/README.md
@@ -44,22 +44,9 @@ For macOS, the host machine must be macOS. All other platforms assume that the h
     dnf install golang-github-rootless-containers-rootlesskit dnsmasq
     ```
 
-## Building test-runner image
-
-You must get a `.deb` or `.exe` of the Mullvad App from https://releases.mullvad.net/releases/ in
-order to load into the testing environment.
-Put the `.deb` or `.exe` in the `packages/` directory then create two symbolic links called
-`current-app.deb/exe` and `previous-app.deb/exe` in the same directory pointing to the downloaded
-Mullvad App `.deb` or `.exe` file.
-
-Then build with:
-```
-./build.sh
-```
-
 # Building base images
 
-See [`BUILD_BASE_IMAGE.md`](./BUILD_BASE_IMAGE.md) for how to build images for running tests on.
+See [`BUILD_OS_IMAGE.md`](./BUILD_OS_IMAGE.md) for how to build images for running tests on.
 
 # Running tests
 Run all tests on Debian using `./runtests.sh`. To run the tests on Windows (on a Linux host), use

--- a/README.md
+++ b/README.md
@@ -23,25 +23,15 @@ For macOS, the host machine must be macOS. All other platforms assume that the h
 
 * Get the latest stable Rust from https://rustup.rs/.
 
-* To run tests on Linux guests, you will need `glibc-static` and `e2tools`. On Fedora, install them
-  using
+* For running tests on Linux and Windows guests, you will need these tools and libraries:
 
     ```
-    dnf install glibc-static e2tools
-    ```
+    dnf install git gcc protobuf-devel libpcap-devel qemu \
+        glibc-static e2tools \
+        mingw64-gcc mingw64-winpthreads-static mtools \
+        golang-github-rootless-containers-rootlesskit slirp4netns dnsmasq
 
-* To run tests on Windows guests, you'll need some toolchains and libraries, and `mtools`:
-
-    ```
     rustup target add x86_64-pc-windows-gnu
-    dnf install mingw64-gcc mingw64-winpthreads-static mtools
-    ```
-
-* `rootlesskit` is used to set up an isolated network namespace with `slirp`,
-  and `dnsmasq` to assign IPs to VMs/containers.
-
-    ```
-    dnf install golang-github-rootless-containers-rootlesskit dnsmasq
     ```
 
 # Building base images

--- a/build.sh
+++ b/build.sh
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+
 set -eu
 
 RUSTFLAGS="-C target-feature=+crt-static" cargo build --bin test-runner --release --target "${TARGET}"

--- a/ci-runtests.sh
+++ b/ci-runtests.sh
@@ -1,0 +1,149 @@
+#!/usr/bin/env bash
+
+set -eu
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+cd "$SCRIPT_DIR"
+
+git pull
+
+# Use complete version strings: e.g. 2022.5, or 2022.5-dev-6efde7
+OLD_APP_VERSION=$1
+NEW_APP_VERSION=$2
+
+TARGET_OS="debian"
+
+BUILD_RELEASE_REPOSITORY="https://releases.mullvad.net/releases/"
+BUILD_DEV_REPOSITORY="https://releases.mullvad.net/builds/"
+
+APP_REPO_URL="https://github.com/mullvad/mullvadvpn-app"
+
+# Returns 0 if $1 is a development build. `BASH_REMATCH` contains match groups
+# if that is the case.
+function is_dev_version {
+    if [[ $1 =~ (^[0-9.]+(-beta[0-9]+)?-dev-)([0-9a-z]+)$ ]]; then
+        return 0
+    fi
+    return 1
+}
+
+function find_version_commit {
+    local commit=""
+
+    if is_dev_version $1; then
+        # dev version
+        commit="${BASH_REMATCH[3]}"
+    else
+        # release version
+        commit=$(git ls-remote "${APP_REPO_URL}" $1)
+    fi
+
+    if [[ -z "${commit}" ]]; then
+        echo "Failed to identify commit hash for version: $1" 1>&2
+        return 1
+    fi
+
+    echo ${commit:0:6}
+}
+
+function get_app_filename {
+    local version=$1
+    if is_dev_version $version; then
+        # only save 6 chars of the hash
+        local commit="${BASH_REMATCH[3]}"
+        version="${BASH_REMATCH[1]}${commit:0:6}"
+    fi
+    case $TARGET_OS in
+        debian)
+            echo "MullvadVPN-${version}_amd64.deb"
+            ;;
+        windows)
+            echo "MullvadVPN-${version}.exe"
+            ;;
+        *)
+            echo "Unsupported OS: $TARGET_OS" 1>&2
+            return 1
+            ;;
+    esac
+}
+
+function download_app_package {
+    local version=$1
+    local package_repo=""
+
+    if is_dev_version $1; then
+        package_repo="${BUILD_DEV_REPOSITORY}"
+    else
+        package_repo="${BUILD_RELEASE_REPOSITORY}"
+    fi
+
+    local filename=$(get_app_filename $1)
+    local url="${package_repo}/$1/$filename"
+
+    # TODO: integrity check
+
+    echo "Downloading build for $1 from $url"
+    mkdir -p "$SCRIPT_DIR/packages/"
+    if [[ ! -f "$SCRIPT_DIR/packages/$filename" ]]; then
+        curl -f -o "$SCRIPT_DIR/packages/$filename" $url
+    fi
+}
+
+function backup_version_metadata {
+    cp ${SCRIPT_DIR}/Cargo.lock{,.bak}
+    cp ${SCRIPT_DIR}/test-rpc/Cargo.toml{,.bak}
+    cp ${SCRIPT_DIR}/test-runner/Cargo.toml{,.bak}
+    cp ${SCRIPT_DIR}/test-manager/Cargo.toml{,.bak}
+}
+
+function restore_version_metadata {
+    mv ${SCRIPT_DIR}/test-manager/Cargo.toml{.bak,}
+    mv ${SCRIPT_DIR}/test-runner/Cargo.toml{.bak,}
+    mv ${SCRIPT_DIR}/test-rpc/Cargo.toml{.bak,}
+    mv ${SCRIPT_DIR}/Cargo.lock{.bak,}
+}
+
+old_app_commit=$(find_version_commit $OLD_APP_VERSION)
+new_app_commit=$(find_version_commit $NEW_APP_VERSION)
+
+echo "Version to upgrade from: $old_app_commit ($OLD_APP_VERSION)"
+echo "Version to test: $new_app_commit ($NEW_APP_VERSION)"
+
+download_app_package $OLD_APP_VERSION
+download_app_package $NEW_APP_VERSION
+
+echo "Updating Cargo manifests"
+
+backup_version_metadata
+trap "restore_version_metadata" EXIT
+
+pushd ${SCRIPT_DIR}/test-manager
+for new_dep in mullvad-management-interface mullvad-types mullvad-api talpid-types; do
+    cargo add --git "${APP_REPO_URL}" --rev ${new_app_commit} ${new_dep}
+done
+cargo add --git "${APP_REPO_URL}" --rev ${old_app_commit} --rename old-mullvad-management-interface mullvad-management-interface
+popd
+
+pushd ${SCRIPT_DIR}/test-runner
+cargo add --git "${APP_REPO_URL}" --rev ${new_app_commit} mullvad-management-interface
+cargo add --git "${APP_REPO_URL}" --rev ${new_app_commit} talpid-windows-net --target "cfg(target_os=\"windows\")"
+cargo add --git "${APP_REPO_URL}" --rev ${new_app_commit} mullvad-paths --target "cfg(target_os=\"windows\")"
+popd
+
+export PREVIOUS_APP_FILENAME=$(get_app_filename $OLD_APP_VERSION)
+export CURRENT_APP_FILENAME=$(get_app_filename $NEW_APP_VERSION)
+
+case $TARGET_OS in
+    debian)
+        export TARGET="x86_64-unknown-linux-gnu"
+        ;;
+    windows)
+        export TARGET="x86_64-pc-windows-gnu"
+        ;;
+    *)
+        echo "Unsupported OS: $TARGET_OS" 1>&2
+        return 1
+        ;;
+esac
+
+./runtests.sh

--- a/runtests.sh
+++ b/runtests.sh
@@ -55,7 +55,7 @@ function run_tests {
 
 function trap_handler {
     if [[ -n "${QEMU_PID+x}" ]]; then
-        kill --timeout 5000 KILL -TERM -- $QEMU_PID >/dev/null 2>&1 || true
+        env kill --timeout 5000 KILL -TERM -- $QEMU_PID >/dev/null 2>&1 || true
     fi
 
     if [[ $TARGET == *-darwin ]]; then

--- a/runtests.sh
+++ b/runtests.sh
@@ -50,12 +50,12 @@ function run_tests {
     echo "Executing tests"
 
     sleep 1
-    sudo RUST_LOG=debug ACCOUNT_TOKEN=${ACCOUNT_TOKEN} HOST_NET_INTERFACE=${HOST_NET_INTERFACE} ./target/debug/test-manager ${pty} $@
+    RUST_LOG=debug ACCOUNT_TOKEN=${ACCOUNT_TOKEN} HOST_NET_INTERFACE=${HOST_NET_INTERFACE} ./target/debug/test-manager ${pty} $@
 }
 
 function trap_handler {
     if [[ -n "${QEMU_PID+x}" ]]; then
-        sudo kill --timeout 5000 KILL -TERM -- $QEMU_PID >/dev/null 2>&1 || true
+        kill --timeout 5000 KILL -TERM -- $QEMU_PID >/dev/null 2>&1 || true
     fi
 
     if [[ $TARGET == *-darwin ]]; then
@@ -67,7 +67,7 @@ function trap_handler {
     if [[ -n "${HOST_NET_INTERFACE+x}" ]] &&
           ip link show "${HOST_NET_INTERFACE}" >&/dev/null; then
         echo "Removing interface ${HOST_NET_INTERFACE}"
-        sudo ip link del dev ${HOST_NET_INTERFACE}
+        ip link del dev ${HOST_NET_INTERFACE}
     fi
 }
 
@@ -91,19 +91,19 @@ if [[ $TARGET == *-darwin ]]; then
 fi
 
 # Check if we need to setup the network
-ip link show br-mullvadtest >&/dev/null || sudo ./scripts/setup-network.sh
+ip link show br-mullvadtest >&/dev/null || ./scripts/setup-network.sh
 
 HOST_NET_INTERFACE=tap-mullvad$(cat /dev/urandom | tr -dc 'a-z' | head -c 4)
 
 echo "Creating network interface $HOST_NET_INTERFACE"
 
-sudo ip tuntap add ${HOST_NET_INTERFACE} mode tap
-sudo ip link set ${HOST_NET_INTERFACE} master br-mullvadtest
-sudo ip link set ${HOST_NET_INTERFACE} up
+ip tuntap add ${HOST_NET_INTERFACE} mode tap
+ip link set ${HOST_NET_INTERFACE} master br-mullvadtest
+ip link set ${HOST_NET_INTERFACE} up
 
 echo "Launching guest VM"
 
-sudo qemu-system-x86_64 -cpu host -accel kvm -m 2048 -smp 2 \
+qemu-system-x86_64 -cpu host -accel kvm -m 2048 -smp 2 \
     -snapshot \
     -drive file="${OSIMAGE}" \
     -drive if=none,id=runner,file="${RUNNERIMAGE}" \

--- a/runtests.sh
+++ b/runtests.sh
@@ -25,8 +25,6 @@ else
     DISPLAY_ARG=""
 fi
 
-LAUNCH_ONLY=${LAUNCH_ONLY:-""}
-
 case $TARGET in
 
     "x86_64-unknown-linux-gnu")
@@ -69,7 +67,7 @@ function trap_handler {
     fi
 
     if [[ $TARGET == *-darwin ]]; then
-        if [[ -z ${LAUNCH_ONLY} ]]; then
+        if [[ -n ${SHOW_DISPLAY+x} ]]; then
             open "utm://stop?name=mullvad-macOS"
         fi
     fi
@@ -129,9 +127,9 @@ qemu-system-x86_64 -cpu host -accel kvm -m 2048 -smp 2 \
 
 QEMU_PID=$!
 
-if [[ -n ${LAUNCH_ONLY} ]]; then
+run_tests ${pty} $@
+
+if [[ -n ${SHOW_DISPLAY+x} ]]; then
     wait -f $QEMU_PID
     exit 0
 fi
-
-run_tests ${pty} $@

--- a/scripts/setup-network.sh
+++ b/scripts/setup-network.sh
@@ -39,4 +39,4 @@ ip addr add dev net-mullvadtest 1.3.3.7
 
 # start DHCP server
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-dnsmasq -i br-mullvadtest -F "${VIRTUAL_NET_IP_FIRST},${VIRTUAL_NET_IP_LAST}" -x "${SCRIPT_DIR}/.dnsmasq.pid"
+dnsmasq -i br-mullvadtest -F "${VIRTUAL_NET_IP_FIRST},${VIRTUAL_NET_IP_LAST}" -x "${SCRIPT_DIR}/.dnsmasq.pid" -l "${SCRIPT_DIR}/.dnsmasq.leases"

--- a/scripts/setup-network.sh
+++ b/scripts/setup-network.sh
@@ -8,10 +8,7 @@ VIRTUAL_NET_IP_LAST=172.29.1.128
 
 ip link show br-mullvadtest >&/dev/null && exit 0
 
-if [[ "$(cat /proc/sys/net/ipv4/ip_forward)" -eq 0 ]]; then
-    echo "IP forwarding must be enabled for guests to reach the internet"
-    exit 1
-fi
+sysctl net.ipv4.ip_forward=1
 
 ip link add br-mullvadtest type bridge
 ip addr add dev br-mullvadtest $VIRTUAL_NET
@@ -26,10 +23,6 @@ table ip mullvad_test_nat {
     }
 }
 EOF
-
-if systemctl status firewalld >&/dev/null; then
-    firewall-cmd --zone=trusted --change-interface=br-mullvadtest
-fi
 
 # set up pingable hosts
 ip link add lan-mullvadtest type dummy

--- a/test-manager/Cargo.toml
+++ b/test-manager/Cargo.toml
@@ -9,13 +9,13 @@ tarpc = { version = "0.30", features = ["tokio1", "serde-transport", "serde1"] }
 tokio = { version = "1.0", features = ["macros", "rt", "process", "time", "fs", "io-util", "rt-multi-thread"] }
 tokio-serial = "5.4.1"
 err-derive = "0.3.1"
-bytes = "*"
+bytes = "1.3.0"
 test_macro = { path = "./test_macro" }
 ipnetwork = "0.16"
 
-tokio-serde = { version = "*", features = ["json"] }
+serde = "1.0"
+tokio-serde = { version = "0.8.0", features = ["json"] }
 log = "0.4.17"
-serde = "*"
 
 pcap = { version = "0.10.1", features = ["capture-stream"] }
 pnet_packet = "0.31.0"

--- a/test-manager/Cargo.toml
+++ b/test-manager/Cargo.toml
@@ -21,9 +21,6 @@ log = "0.4.17"
 pcap = { version = "0.10.1", features = ["capture-stream"] }
 pnet_packet = "0.31.0"
 
-talpid-types = { path = "../../mullvadvpn-app/talpid-types" }
-mullvad-types = { path = "../../mullvadvpn-app/mullvad-types" }
-
 test-rpc = { path = "../test-rpc" }
 
 env_logger = "0.9"
@@ -31,12 +28,11 @@ env_logger = "0.9"
 tonic = "0.8"
 tower = "0.4"
 colored = "2.0.0"
-
-# TODO: inject management interface versions
-mullvad-management-interface = { path = "../../mullvadvpn-app/mullvad-management-interface" }
-old-mullvad-management-interface = { package = "mullvad-management-interface", git = "https://github.com/mullvad/mullvadvpn-app", rev = "2022.5" }
-
-mullvad-api = { path = "../../mullvadvpn-app/mullvad-api" }
+mullvad-management-interface = { git = "https://github.com/mullvad/mullvadvpn-app" }
+old-mullvad-management-interface = { git = "https://github.com/mullvad/mullvadvpn-app", rev = "2022.5", package = "mullvad-management-interface" }
+talpid-types = { git = "https://github.com/mullvad/mullvadvpn-app" }
+mullvad-types = { git = "https://github.com/mullvad/mullvadvpn-app" }
+mullvad-api = { git = "https://github.com/mullvad/mullvadvpn-app" }
 
 [dependencies.tokio-util]
 version = "0.7"

--- a/test-manager/Cargo.toml
+++ b/test-manager/Cargo.toml
@@ -12,6 +12,7 @@ err-derive = "0.3.1"
 bytes = "1.3.0"
 test_macro = { path = "./test_macro" }
 ipnetwork = "0.16"
+once_cell = "1.16.0"
 
 serde = "1.0"
 tokio-serde = { version = "0.8.0", features = ["json"] }

--- a/test-manager/src/config.rs
+++ b/test-manager/src/config.rs
@@ -8,3 +8,10 @@ pub static ACCOUNT_TOKEN: Lazy<String> = Lazy::new(|| {
 pub static HOST_NET_INTERFACE: Lazy<String> = Lazy::new(|| {
     std::env::var("HOST_NET_INTERFACE").expect("HOST_NET_INTERFACE is unspecified")
 });
+
+pub static PREVIOUS_APP_FILENAME: Lazy<String> = Lazy::new(|| {
+    std::env::var("PREVIOUS_APP_FILENAME").expect("PREVIOUS_APP_FILENAME is unspecified")
+});
+pub static CURRENT_APP_FILENAME: Lazy<String> = Lazy::new(|| {
+    std::env::var("CURRENT_APP_FILENAME").expect("CURRENT_APP_FILENAME is unspecified")
+});

--- a/test-manager/src/config.rs
+++ b/test-manager/src/config.rs
@@ -1,0 +1,10 @@
+//! Configuration variables for the test manager.
+
+use once_cell::sync::Lazy;
+
+pub static ACCOUNT_TOKEN: Lazy<String> = Lazy::new(|| {
+    std::env::var("ACCOUNT_TOKEN").expect("ACCOUNT_TOKEN is unspecified")
+});
+pub static HOST_NET_INTERFACE: Lazy<String> = Lazy::new(|| {
+    std::env::var("HOST_NET_INTERFACE").expect("HOST_NET_INTERFACE is unspecified")
+});

--- a/test-manager/src/main.rs
+++ b/test-manager/src/main.rs
@@ -1,3 +1,4 @@
+mod config;
 mod logging;
 mod mullvad_daemon;
 mod network_monitor;

--- a/test-manager/src/network_monitor.rs
+++ b/test-manager/src/network_monitor.rs
@@ -3,6 +3,7 @@ use std::{
     time::Duration,
 };
 
+use crate::config::HOST_NET_INTERFACE;
 use futures::{
     channel::oneshot,
     future::{select, Either},
@@ -157,7 +158,7 @@ pub fn start_packet_monitor(
     filter_fn: impl Fn(&ParsedPacket) -> bool + Send + 'static,
     monitor_options: MonitorOptions,
 ) -> PacketMonitor {
-    let dev = pcap::Capture::from_device(&*host_tap_interface())
+    let dev = pcap::Capture::from_device(HOST_NET_INTERFACE.as_str())
         .expect("Failed to open capture handle")
         .immediate_mode(true)
         .open()
@@ -229,8 +230,4 @@ pub fn start_packet_monitor(
     });
 
     PacketMonitor { stop_tx, handle }
-}
-
-fn host_tap_interface() -> String {
-    std::env::var("HOST_NET_INTERFACE").expect("HOST_NET_INTERFACE is unspecified")
 }

--- a/test-manager/src/tests/mod.rs
+++ b/test-manager/src/tests/mod.rs
@@ -131,7 +131,7 @@ pub mod manager_tests {
         let mut ctx = context::current();
         ctx.deadline = SystemTime::now().checked_add(INSTALL_TIMEOUT).unwrap();
 
-        rpc.install_app(ctx, get_package_desc(&rpc, "previous-app").await?)
+        rpc.install_app(ctx, get_package_desc(&rpc, &*PREVIOUS_APP_FILENAME).await?)
             .await?
             .map_err(|err| Error::Package("previous app", err))?;
 
@@ -239,7 +239,7 @@ pub mod manager_tests {
         let mut ctx = context::current();
         ctx.deadline = SystemTime::now().checked_add(INSTALL_TIMEOUT).unwrap();
 
-        rpc.install_app(ctx, get_package_desc(&rpc, "current-app").await?)
+        rpc.install_app(ctx, get_package_desc(&rpc, &*CURRENT_APP_FILENAME).await?)
             .await?
             .map_err(|error| Error::Package("current app", error))?;
 
@@ -392,7 +392,7 @@ pub mod manager_tests {
         let mut ctx = context::current();
         ctx.deadline = SystemTime::now().checked_add(INSTALL_TIMEOUT).unwrap();
 
-        rpc.install_app(ctx, get_package_desc(&rpc, "current-app").await?)
+        rpc.install_app(ctx, get_package_desc(&rpc, &*CURRENT_APP_FILENAME).await?)
             .await?
             .map_err(|err| Error::Package("current app", err))?;
 
@@ -408,11 +408,11 @@ pub mod manager_tests {
         match rpc.get_os(context::current()).await.map_err(Error::Rpc)? {
             meta::Os::Linux => Ok(Package {
                 r#type: PackageType::Dpkg,
-                path: Path::new(&format!("/opt/testing/{}.deb", name)).to_path_buf(),
+                path: Path::new(&format!("/opt/testing/{}", name)).to_path_buf(),
             }),
             meta::Os::Windows => Ok(Package {
                 r#type: PackageType::NsisExe,
-                path: Path::new(&format!(r"E:\{}.exe", name)).to_path_buf(),
+                path: Path::new(&format!(r"E:\{}", name)).to_path_buf(),
             }),
             _ => unimplemented!(),
         }

--- a/test-manager/src/tests/mod.rs
+++ b/test-manager/src/tests/mod.rs
@@ -1,6 +1,7 @@
 mod test_metadata;
 
 use crate::network_monitor::{start_packet_monitor, MonitorOptions};
+use crate::config::*;
 use mullvad_management_interface::{
     types::{self, RelayLocation},
     ManagementServiceClient,
@@ -167,7 +168,7 @@ pub mod manager_tests {
         }
 
         // Login to test preservation of device/account
-        mullvad_client.login_account(account_token()).await.expect("login failed");
+        mullvad_client.login_account(ACCOUNT_TOKEN.clone()).await.expect("login failed");
 
         //
         // Start blocking
@@ -312,8 +313,7 @@ pub mod manager_tests {
 
         // check if account history was preserved
         let history = mullvad_client.get_account_history(()).await.expect("failed to obtain account history");
-        let expected_account = account_token();
-        assert_eq!(history.into_inner().token, Some(expected_account), "lost account history");
+        assert_eq!(history.into_inner().token, Some(ACCOUNT_TOKEN.clone()), "lost account history");
 
         // TODO: check version
 
@@ -368,7 +368,7 @@ pub mod manager_tests {
         ).await;
         let device_client = mullvad_api::DevicesProxy::new(rest_handle);
 
-        let devices = device_client.list(account_token()).await.expect("failed to list devices");
+        let devices = device_client.list(ACCOUNT_TOKEN.clone()).await.expect("failed to list devices");
 
         assert!(
             devices.iter().find(|device| device.id == uninstalled_device).is_none(),
@@ -458,10 +458,8 @@ pub mod manager_tests {
 
         log::info!("Logging in/generating device");
 
-        let account = account_token();
-
         mullvad_client
-            .login_account(account)
+            .login_account(ACCOUNT_TOKEN.clone())
             .await
             .expect("login failed");
 
@@ -487,10 +485,6 @@ pub mod manager_tests {
         // TODO: verify that the device was deleted
 
         Ok(())
-    }
-
-    pub fn account_token() -> String {
-        std::env::var("ACCOUNT_TOKEN").expect("ACCOUNT_TOKEN is unspecified")
     }
 
     /// Try to produce leaks in the connecting state by forcing

--- a/test-rpc/Cargo.toml
+++ b/test-rpc/Cargo.toml
@@ -8,10 +8,10 @@ description = "Supports IPC between test-runner and test-manager"
 futures = "0.3"
 tokio = { version = "1.0", features = ["macros", "rt", "process", "time", "fs", "io-util", "rt-multi-thread"] }
 tarpc = { version = "0.30", features = ["tokio1", "serde-transport", "serde1"] }
-serde = "*"
-tokio-serde = { version = "*", features = ["json"] }
-serde_json = "*"
-bytes = "*"
+serde = "1.0"
+tokio-serde = { version = "0.8.0", features = ["json"] }
+serde_json = "1.0"
+bytes = "1.3.0"
 err-derive = "0.3.1"
 log = "0.4.17"
 colored = "2.0.0"

--- a/test-rpc/src/lib.rs
+++ b/test-rpc/src/lib.rs
@@ -45,11 +45,10 @@ pub enum AppTrace {
 #[tarpc::service]
 pub trait Service {
     /// Install app package.
-    async fn install_app(package_path: package::Package)
-        -> package::Result<package::InstallResult>;
+    async fn install_app(package_path: package::Package) -> package::Result<()>;
 
     /// Remove app package.
-    async fn uninstall_app() -> package::Result<package::InstallResult>;
+    async fn uninstall_app() -> package::Result<()>;
 
     async fn poll_output() -> mullvad_daemon::Result<Vec<logging::Output>>;
 

--- a/test-rpc/src/package.rs
+++ b/test-rpc/src/package.rs
@@ -24,6 +24,12 @@ pub enum Error {
 
     #[error(display = "Failed to create temporary uninstaller")]
     CreateTempUninstaller,
+
+    #[error(display = "Installer or uninstaller failed due to an unknown error: {}", _0)]
+    InstallerFailed(i32),
+
+    #[error(display = "Installer or uninstaller failed due to a signal")]
+    InstallerFailedSignal,
 }
 
 pub type Result<T> = std::result::Result<T, Error>;
@@ -40,6 +46,3 @@ pub enum PackageType {
     Rpm,
     NsisExe,
 }
-
-#[derive(Debug, Deserialize, Serialize)]
-pub struct InstallResult(pub Option<i32>);

--- a/test-runner/Cargo.toml
+++ b/test-runner/Cargo.toml
@@ -21,15 +21,13 @@ hyper = { version = "0.14.23", features = ["client", "http2"] }
 hyper-rustls = "0.23"
 tokio-rustls = "0.23"
 rustls-pemfile = "0.2"
-
-# FIXME: use SUT version
-mullvad-management-interface = { path = "../../mullvadvpn-app/mullvad-management-interface" }
+mullvad-management-interface = { git = "https://github.com/mullvad/mullvadvpn-app" }
 
 test-rpc = { path = "../test-rpc" }
 
-[target.'cfg(target_os = "windows")'.dependencies]
-talpid-windows-net = { path = "../../mullvadvpn-app/talpid-windows-net" }
-mullvad-paths = { path = "../../mullvadvpn-app/mullvad-paths" }
+[target."cfg(target_os=\"windows\")".dependencies]
+mullvad-paths = { git = "https://github.com/mullvad/mullvadvpn-app" }
+talpid-windows-net = { git = "https://github.com/mullvad/mullvadvpn-app" }
 
 [dependencies.tokio-util]
 version = "0.7"

--- a/test-runner/Cargo.toml
+++ b/test-runner/Cargo.toml
@@ -5,18 +5,19 @@ edition = "2021"
 
 [dependencies]
 futures = "0.3"
-bytes = "*"
 tarpc = { version = "0.30", features = ["tokio1", "serde-transport", "serde1"] }
 tokio = { version = "1.0", features = ["macros", "rt", "process", "time", "fs", "io-util", "rt-multi-thread"] }
 tokio-serial = "5.4.1"
-tokio-serde = { version = "*", features = ["json"] }
 err-derive = "0.3.1"
 log = "0.4.17"
 lazy_static = "1.4.0"
+parity-tokio-ipc = "0.9"
+bytes = "1.3.0"
 serde = { version = "1.0" }
 serde_json = "1.0"
-parity-tokio-ipc = "0.9"
-hyper = { version = "*", features = ["client", "http2"] }
+tokio-serde = { version = "0.8.0", features = ["json"] }
+
+hyper = { version = "0.14.23", features = ["client", "http2"] }
 hyper-rustls = "0.23"
 tokio-rustls = "0.23"
 rustls-pemfile = "0.2"

--- a/test-runner/Cargo.toml
+++ b/test-runner/Cargo.toml
@@ -21,6 +21,7 @@ hyper-rustls = "0.23"
 tokio-rustls = "0.23"
 rustls-pemfile = "0.2"
 
+# FIXME: use SUT version
 mullvad-management-interface = { path = "../../mullvadvpn-app/mullvad-management-interface" }
 
 test-rpc = { path = "../test-rpc" }

--- a/test-runner/src/main.rs
+++ b/test-runner/src/main.rs
@@ -10,7 +10,7 @@ use tarpc::server::Channel;
 use test_rpc::{
     meta,
     mullvad_daemon::{ServiceStatus, SOCKET_PATH},
-    package::{InstallResult, Package},
+    package::Package,
     transport::GrpcForwarder,
     Interface, Service, AppTrace,
 };
@@ -32,7 +32,7 @@ impl Service for TestServer {
         self,
         _: context::Context,
         package: Package,
-    ) -> test_rpc::package::Result<InstallResult> {
+    ) -> test_rpc::package::Result<()> {
         log::debug!("Installing app");
 
         let result = package::install_package(package).await?;
@@ -42,7 +42,7 @@ impl Service for TestServer {
         Ok(result)
     }
 
-    async fn uninstall_app(self, _: context::Context) -> test_rpc::package::Result<InstallResult> {
+    async fn uninstall_app(self, _: context::Context) -> test_rpc::package::Result<()> {
         log::debug!("Uninstalling app");
 
         let result = package::uninstall_app().await?;


### PR DESCRIPTION
This PR includes a number of changes. Primarily the following:
* Set up networking without root access (using `rootlesskit`/`slirp4netns`).
* Add a "CI" script that takes as input any two Mullvad app versions (one version under test and one version to upgrade from) and 
* Clean up "config variables" in the test manager somewhat.