### PR TITLE
Get log files output

### DIFF
--- a/test-manager/src/config.rs
+++ b/test-manager/src/config.rs
@@ -2,12 +2,10 @@
 
 use once_cell::sync::Lazy;
 
-pub static ACCOUNT_TOKEN: Lazy<String> = Lazy::new(|| {
-    std::env::var("ACCOUNT_TOKEN").expect("ACCOUNT_TOKEN is unspecified")
-});
-pub static HOST_NET_INTERFACE: Lazy<String> = Lazy::new(|| {
-    std::env::var("HOST_NET_INTERFACE").expect("HOST_NET_INTERFACE is unspecified")
-});
+pub static ACCOUNT_TOKEN: Lazy<String> =
+    Lazy::new(|| std::env::var("ACCOUNT_TOKEN").expect("ACCOUNT_TOKEN is unspecified"));
+pub static HOST_NET_INTERFACE: Lazy<String> =
+    Lazy::new(|| std::env::var("HOST_NET_INTERFACE").expect("HOST_NET_INTERFACE is unspecified"));
 
 pub static PREVIOUS_APP_FILENAME: Lazy<String> = Lazy::new(|| {
     std::env::var("PREVIOUS_APP_FILENAME").expect("PREVIOUS_APP_FILENAME is unspecified")

--- a/test-rpc/src/lib.rs
+++ b/test-rpc/src/lib.rs
@@ -1,5 +1,8 @@
 use serde::{Deserialize, Serialize};
-use std::{net::{IpAddr, SocketAddr}, path::PathBuf};
+use std::{
+    net::{IpAddr, SocketAddr},
+    path::PathBuf,
+};
 
 pub mod logging;
 pub mod meta;
@@ -50,9 +53,15 @@ pub trait Service {
     /// Remove app package.
     async fn uninstall_app() -> package::Result<()>;
 
-    async fn poll_output() -> mullvad_daemon::Result<Vec<logging::Output>>;
+    /// Get the output of the runners stdout logs since the last time this function was called.
+    /// Block if there is no output until some output is provided by the runner.
+    async fn poll_output() -> logging::Result<Vec<logging::Output>>;
 
-    async fn try_poll_output() -> mullvad_daemon::Result<Vec<logging::Output>>;
+    /// Get the output of the runners stdout logs since the last time this function was called.
+    /// Block if there is no output until some output is provided by the runner.
+    async fn try_poll_output() -> logging::Result<Vec<logging::Output>>;
+
+    async fn get_mullvad_app_logs() -> logging::LogOutput;
 
     /// Return the OS of the guest.
     async fn get_os() -> meta::Os;

--- a/test-rpc/src/logging.rs
+++ b/test-rpc/src/logging.rs
@@ -1,6 +1,16 @@
 use colored::Colorize;
 use serde::{Deserialize, Serialize};
 
+pub type Result<T> = std::result::Result<T, Error>;
+
+#[derive(err_derive::Error, Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
+pub enum Error {
+    #[error(display = "Could not get standard output from runner")]
+    StandardOutput,
+    #[error(display = "Could not get mullvad app logs from runner")]
+    Logs(String),
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum Output {
     Error(String),
@@ -18,4 +28,16 @@ impl std::fmt::Display for Output {
             Output::Other(s) => f.write_fmt(format_args!("{}", s.as_str())),
         }
     }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct LogOutput {
+    pub settings_json: Result<String>,
+    pub log_files: Result<Vec<Result<LogFile>>>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct LogFile {
+    pub name: std::path::PathBuf,
+    pub content: String,
 }

--- a/test-rpc/src/mullvad_daemon.rs
+++ b/test-rpc/src/mullvad_daemon.rs
@@ -9,7 +9,6 @@ pub const SOCKET_PATH: &str = "//./pipe/Mullvad VPN";
 pub enum Error {
     ConnectError,
     DisconnectError,
-    CanNotGetOutput,
     DaemonError(String),
 }
 

--- a/test-rpc/src/package.rs
+++ b/test-rpc/src/package.rs
@@ -25,7 +25,10 @@ pub enum Error {
     #[error(display = "Failed to create temporary uninstaller")]
     CreateTempUninstaller,
 
-    #[error(display = "Installer or uninstaller failed due to an unknown error: {}", _0)]
+    #[error(
+        display = "Installer or uninstaller failed due to an unknown error: {}",
+        _0
+    )]
     InstallerFailed(i32),
 
     #[error(display = "Installer or uninstaller failed due to a signal")]

--- a/test-runner/Cargo.toml
+++ b/test-runner/Cargo.toml
@@ -24,9 +24,9 @@ rustls-pemfile = "0.2"
 mullvad-management-interface = { git = "https://github.com/mullvad/mullvadvpn-app" }
 
 test-rpc = { path = "../test-rpc" }
+mullvad-paths = { git = "https://github.com/mullvad/mullvadvpn-app" }
 
 [target."cfg(target_os=\"windows\")".dependencies]
-mullvad-paths = { git = "https://github.com/mullvad/mullvadvpn-app" }
 talpid-windows-net = { git = "https://github.com/mullvad/mullvadvpn-app" }
 
 [dependencies.tokio-util]

--- a/test-runner/src/app.rs
+++ b/test-runner/src/app.rs
@@ -15,18 +15,19 @@ pub fn find_traces() -> Result<Vec<AppTrace>, Error> {
 
     let mut traces = vec![
         Path::new(r"C:\Program Files\Mullvad VPN"),
-
         // NOTE: This only works as of `499c06decda37dc639e5f` in the Mullvad app.
         // Older builds have no way of silently fully uninstalling the app.
         Path::new(r"C:\ProgramData\Mullvad VPN"),
-
         // NOTE: Works as of `4116ebc` (Mullvad app).
         &settings_dir,
     ];
 
     filter_non_existent_paths(&mut traces)?;
 
-    Ok(traces.into_iter().map(|path| AppTrace::Path(path.to_path_buf())).collect())
+    Ok(traces
+        .into_iter()
+        .map(|path| AppTrace::Path(path.to_path_buf()))
+        .collect())
 }
 
 #[cfg(target_os = "linux")]
@@ -39,19 +40,15 @@ pub fn find_traces() -> Result<Vec<AppTrace>, Error> {
         Path::new(r"/var/log/mullvad-vpn/"),
         Path::new(r"/var/cache/mullvad-vpn/"),
         Path::new(r"/opt/Mullvad VPN/"),
-
         // management interface socket
         Path::new(r"/var/run/mullvad-vpn"),
-
         // service unit config files
         Path::new(r"/usr/lib/systemd/system/mullvad-daemon.service"),
         Path::new(r"/usr/lib/systemd/system/mullvad-early-boot-blocking.service"),
-
         Path::new(r"/usr/bin/mullvad"),
         Path::new(r"/usr/bin/mullvad-daemon"),
         Path::new(r"/usr/bin/mullvad-exclude"),
         Path::new(r"/usr/bin/mullvad-problem-report"),
-
         Path::new(r"/usr/share/bash-completion/completions/mullvad"),
         Path::new(r"/usr/local/share/zsh/site-functions/_mullvad"),
         Path::new(r"/usr/share/fish/vendor_completions.d/mullvad.fish"),
@@ -59,7 +56,10 @@ pub fn find_traces() -> Result<Vec<AppTrace>, Error> {
 
     filter_non_existent_paths(&mut traces)?;
 
-    Ok(traces.into_iter().map(|path| AppTrace::Path(path.to_path_buf())).collect())
+    Ok(traces
+        .into_iter()
+        .map(|path| AppTrace::Path(path.to_path_buf()))
+        .collect())
 }
 
 #[cfg(target_os = "macos")]

--- a/test-runner/src/logging.rs
+++ b/test-runner/src/logging.rs
@@ -1,9 +1,14 @@
 use lazy_static::lazy_static;
 use log::{Level, LevelFilter, Metadata, Record, SetLoggerError};
-use test_rpc::logging::Output;
-use tokio::sync::{
-    broadcast::{channel, Receiver, Sender},
-    Mutex,
+use std::path::{Path, PathBuf};
+use test_rpc::logging::Error;
+use test_rpc::logging::{LogFile, LogOutput, Output};
+use tokio::{
+    fs::read_to_string,
+    sync::{
+        broadcast::{channel, Receiver, Sender},
+        Mutex,
+    },
 };
 
 const MAX_OUTPUT_BUFFER: usize = 10_000;
@@ -52,4 +57,56 @@ impl log::Log for StdOutBuffer {
 
 pub fn init_logger() -> Result<(), SetLoggerError> {
     log::set_logger(&*LOGGER).map(|()| log::set_max_level(LevelFilter::Info))
+}
+
+pub async fn get_mullvad_app_logs() -> LogOutput {
+    LogOutput {
+        settings_json: read_settings_file().await,
+        log_files: read_log_files().await,
+    }
+}
+
+async fn read_settings_file() -> Result<String, Error> {
+    let mut settings_path = mullvad_paths::get_default_settings_dir()
+        .map_err(|error| Error::Logs(format!("{}", error)))?;
+    settings_path.push("settings.json");
+    read_to_string(&settings_path)
+        .await
+        .map_err(|error| Error::Logs(format!("{}: {}", settings_path.display(), error)))
+}
+
+async fn read_log_files() -> Result<Vec<Result<LogFile, Error>>, Error> {
+    let log_dir =
+        mullvad_paths::get_default_log_dir().map_err(|error| Error::Logs(format!("{}", error)))?;
+    let paths = list_logs(log_dir)
+        .await
+        .map_err(|error| Error::Logs(format!("{}", error)))?;
+    let mut log_files = Vec::new();
+    for path in paths {
+        let log_file = read_to_string(&path)
+            .await
+            .map_err(|error| Error::Logs(format!("{}: {}", path.display(), error)))
+            .map(|content| LogFile {
+                content,
+                name: path,
+            });
+        log_files.push(log_file);
+    }
+    Ok(log_files)
+}
+
+async fn list_logs<T: AsRef<Path>>(log_dir: T) -> Result<Vec<PathBuf>, Error> {
+    let mut dir_entries = tokio::fs::read_dir(&log_dir)
+        .await
+        .map_err(|e| Error::Logs(format!("{}: {}", log_dir.as_ref().display(), e)))?;
+    let log_extension = Some(std::ffi::OsStr::new("log"));
+
+    let mut paths = Vec::new();
+    while let Ok(Some(entry)) = dir_entries.next_entry().await {
+        let path = entry.path();
+        if path.extension() == log_extension {
+            paths.push(path);
+        }
+    }
+    Ok(paths)
 }

--- a/test-runner/src/net.rs
+++ b/test-runner/src/net.rs
@@ -1,6 +1,9 @@
 use hyper::{Client, Uri};
 use serde::de::DeserializeOwned;
-use std::{net::{IpAddr, SocketAddr}, process::Output};
+use std::{
+    net::{IpAddr, SocketAddr},
+    process::Output,
+};
 use test_rpc::{AmIMullvad, Interface};
 use tokio::{
     io::AsyncWriteExt,
@@ -252,6 +255,11 @@ fn result_from_output(action: &'static str, output: Output) -> Result<(), ()> {
     let stdout_str = std::str::from_utf8(&output.stdout).unwrap_or("non-utf8 string");
     let stderr_str = std::str::from_utf8(&output.stderr).unwrap_or("non-utf8 string");
 
-    log::error!("{action} failed:\n\ncode: {:?}\n\nstdout:\n\n{}\n\nstderr\n\n{}", output.status.code(), stdout_str, stderr_str);
+    log::error!(
+        "{action} failed:\n\ncode: {:?}\n\nstdout:\n\n{}\n\nstderr\n\n{}",
+        output.status.code(),
+        stdout_str,
+        stderr_str
+    );
     Err(())
 }

--- a/test-runner/src/package.rs
+++ b/test-runner/src/package.rs
@@ -1,6 +1,10 @@
 // TODO: Fix terrible abstraction
 
-use std::{ffi::OsStr, path::Path, process::{Output, Stdio}};
+use std::{
+    ffi::OsStr,
+    path::Path,
+    process::{Output, Stdio},
+};
 use test_rpc::package::{Error, Package, PackageType, Result};
 use tokio::process::Command;
 
@@ -124,7 +128,15 @@ fn result_from_output(action: &'static str, output: Output) -> Result<()> {
     let stdout_str = std::str::from_utf8(&output.stdout).unwrap_or("non-utf8 string");
     let stderr_str = std::str::from_utf8(&output.stderr).unwrap_or("non-utf8 string");
 
-    log::error!("{action} failed:\n\nstdout:\n\n{}\n\nstderr\n\n{}", stdout_str, stderr_str);
+    log::error!(
+        "{action} failed:\n\nstdout:\n\n{}\n\nstderr\n\n{}",
+        stdout_str,
+        stderr_str
+    );
 
-    Err(output.status.code().map(Error::InstallerFailed).unwrap_or(Error::InstallerFailedSignal))
+    Err(output
+        .status
+        .code()
+        .map(Error::InstallerFailed)
+        .unwrap_or(Error::InstallerFailedSignal))
 }


### PR DESCRIPTION
Print log files and `settings.json` when a test fails.

Currently this always prints this on test failure, not sure if we want to be able to turn this on and off to avoid verbosity, but I imagine that tests failing is supposed to be a rarity and in that case you would want to see a bunch of data.