### PR TITLE
Add scripts/service for running tests nightly and emailing the results

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,6 @@
 /packages
 /os-images
 /testrunner-images
+/.ci-logs
 .dnsmasq.pid
 .dnsmasq.leases

--- a/ci-runtests-and-report.sh
+++ b/ci-runtests-and-report.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+
+set -eu
+
+source $HOME/.cargo/env
+
+EMAIL_SUBJECT_PREFIX="App test results"
+SENDER_EMAIL_ADDR="test@app-test-linux"
+REPORT_ON_SUCCESS=1
+
+if [[ -z "${RECIPIENT_EMAIL_ADDRS+x}" ]]; then
+    echo "'RECIPIENT_EMAIL_ADDRS' must be specified" 1>&2
+    exit 1
+fi
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+cd "$SCRIPT_DIR"
+
+set +e
+exec 3>&1
+REPORT=$(./ci-runtests.sh $@ 2>&1 | tee >(cat >&3); exit ${PIPESTATUS[0]})
+EXIT_STATUS=$?
+set -e
+
+if [[ $REPORT_ON_SUCCESS -eq 0 && $EXIT_STATUS -eq 0 ]]; then
+    echo "Not sending email report since tests were successful"
+    exit 0
+fi
+
+if [[ $EXIT_STATUS -eq 0 ]]; then
+    EMAIL_SUBJECT_SUFFIX=": Succeeded"
+else
+    EMAIL_SUBJECT_SUFFIX=": Failed"
+fi
+
+echo "Sending email reports"
+
+/usr/bin/mailx \
+    -s "${EMAIL_SUBJECT_PREFIX}${EMAIL_SUBJECT_SUFFIX}" \
+    -r "${SENDER_EMAIL_ADDR}" \
+    -S sendcharsets=utf-8 \
+    -S sendwait \
+    "${RECIPIENT_EMAIL_ADDRS}" <<<$REPORT

--- a/ci-runtests.sh
+++ b/ci-runtests.sh
@@ -8,14 +8,17 @@ cd "$SCRIPT_DIR"
 rustup update
 git pull
 
-# Use complete version strings: e.g. 2022.5, or 2022.5-dev-6efde7
-OLD_APP_VERSION=$1
-NEW_APP_VERSION=$2
-
 BUILD_RELEASE_REPOSITORY="https://releases.mullvad.net/releases/"
 BUILD_DEV_REPOSITORY="https://releases.mullvad.net/builds/"
 
 APP_REPO_URL="https://github.com/mullvad/mullvadvpn-app"
+
+# Infer version from GitHub repo
+commit=$(git ls-remote "${APP_REPO_URL}" master)
+commit=${commit:0:6}
+# TODO: make sure OLD_APP_VERSION is stable
+OLD_APP_VERSION=$(curl -f https://raw.githubusercontent.com/mullvad/mullvadvpn-app/${commit}/dist-assets/desktop-product-version.txt)
+NEW_APP_VERSION=${OLD_APP_VERSION}-dev-${commit}
 
 # Returns 0 if $1 is a development build. `BASH_REMATCH` contains match groups
 # if that is the case.

--- a/ci-runtests.sh
+++ b/ci-runtests.sh
@@ -5,13 +5,12 @@ set -eu
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 cd "$SCRIPT_DIR"
 
+rustup update
 git pull
 
 # Use complete version strings: e.g. 2022.5, or 2022.5-dev-6efde7
 OLD_APP_VERSION=$1
 NEW_APP_VERSION=$2
-
-TARGET_OS="debian"
 
 BUILD_RELEASE_REPOSITORY="https://releases.mullvad.net/releases/"
 BUILD_DEV_REPOSITORY="https://releases.mullvad.net/builds/"
@@ -48,20 +47,37 @@ function find_version_commit {
 
 function get_app_filename {
     local version=$1
+    local target=$2
     if is_dev_version $version; then
         # only save 6 chars of the hash
         local commit="${BASH_REMATCH[3]}"
         version="${BASH_REMATCH[1]}${commit:0:6}"
     fi
-    case $TARGET_OS in
-        debian)
+    case $target in
+        "x86_64-unknown-linux-gnu")
             echo "MullvadVPN-${version}_amd64.deb"
             ;;
-        windows)
+        "x86_64-pc-windows-gnu")
             echo "MullvadVPN-${version}.exe"
             ;;
         *)
-            echo "Unsupported OS: $TARGET_OS" 1>&2
+            echo "Unsupported target: $target" 1>&2
+            return 1
+            ;;
+    esac
+}
+
+function get_target_for_os {
+    local os=$1
+    case $os in
+        debian*)
+            echo "x86_64-unknown-linux-gnu"
+            ;;
+        windows*)
+            echo "x86_64-pc-windows-gnu"
+            ;;
+        *)
+            echo "Unsupported OS: $os" 1>&2
             return 1
             ;;
     esac
@@ -69,20 +85,21 @@ function get_app_filename {
 
 function download_app_package {
     local version=$1
+    local target=$2
     local package_repo=""
 
-    if is_dev_version $1; then
+    if is_dev_version $version; then
         package_repo="${BUILD_DEV_REPOSITORY}"
     else
         package_repo="${BUILD_RELEASE_REPOSITORY}"
     fi
 
-    local filename=$(get_app_filename $1)
-    local url="${package_repo}/$1/$filename"
+    local filename=$(get_app_filename $version $target)
+    local url="${package_repo}/$version/$filename"
 
     # TODO: integrity check
 
-    echo "Downloading build for $1 from $url"
+    echo "Downloading build for $version ($target) from $url"
     mkdir -p "$SCRIPT_DIR/packages/"
     if [[ ! -f "$SCRIPT_DIR/packages/$filename" ]]; then
         curl -f -o "$SCRIPT_DIR/packages/$filename" $url
@@ -106,13 +123,14 @@ function restore_version_metadata {
 old_app_commit=$(find_version_commit $OLD_APP_VERSION)
 new_app_commit=$(find_version_commit $NEW_APP_VERSION)
 
-echo "Version to upgrade from: $old_app_commit ($OLD_APP_VERSION)"
-echo "Version to test: $new_app_commit ($NEW_APP_VERSION)"
+echo "**********************************"
+echo "* Version to upgrade from: $OLD_APP_VERSION"
+echo "* Version to test: $NEW_APP_VERSION"
+echo "**********************************"
 
-download_app_package $OLD_APP_VERSION
-download_app_package $NEW_APP_VERSION
-
-echo "Updating Cargo manifests"
+echo "**********************************"
+echo "* Updating Cargo manifests"
+echo "**********************************"
 
 backup_version_metadata
 trap "restore_version_metadata" EXIT
@@ -130,23 +148,44 @@ cargo add --git "${APP_REPO_URL}" --rev ${new_app_commit} talpid-windows-net --t
 cargo add --git "${APP_REPO_URL}" --rev ${new_app_commit} mullvad-paths --target "cfg(target_os=\"windows\")"
 popd
 
-export PREVIOUS_APP_FILENAME=$(get_app_filename $OLD_APP_VERSION)
-export CURRENT_APP_FILENAME=$(get_app_filename $NEW_APP_VERSION)
+function run_tests_for_os {
+    local os=$1
 
-case $TARGET_OS in
-    debian)
-        export TARGET="x86_64-unknown-linux-gnu"
-        ;;
-    windows)
-        export TARGET="x86_64-pc-windows-gnu"
-        ;;
-    *)
-        echo "Unsupported OS: $TARGET_OS" 1>&2
-        return 1
-        ;;
-esac
+    local target=$(get_target_for_os $os)
+    local prev_filename=$(get_app_filename $OLD_APP_VERSION $target)
+    local cur_filename=$(get_app_filename $NEW_APP_VERSION $target)
+    local target=""
 
-# Clear the devices from the account
+    OS=$os \
+    SKIP_COMPILATION=1 \
+    PREVIOUS_APP_FILENAME=$prev_filename \
+    CURRENT_APP_FILENAME=$cur_filename \
+    ./runtests.sh
+}
+
+echo "**********************************"
+echo "* Building test runners"
+echo "**********************************"
+
+# Clean up packages. Leaving stable versions as they rarely change.
+rm -f ${SCRIPT_DIR}/packages/*-dev-*
+
+for target in x86_64-unknown-linux-gnu x86_64-pc-windows-gnu; do
+    download_app_package $OLD_APP_VERSION $target
+    download_app_package $NEW_APP_VERSION $target
+    TARGET=$target ./build.sh
+done
+
+echo "**********************************"
+echo "* Building test manager"
+echo "**********************************"
+
+cargo build -p test-manager
+
+echo "**********************************"
+echo "* Clear devices from account"
+echo "**********************************"
+
 access_token=$(curl -X POST https://api.mullvad.net/auth/v1/token -d "{\"account_number\":\"$ACCOUNT_TOKEN\"}" -H "Content-Type:application/json" | jq -r .access_token)
 device_ids=$(curl https://api.mullvad.net/accounts/v1/devices -H "AUTHORIZATION:Bearer $access_token" | jq -r '.[].id')
 for d_id in $(xargs <<< $device_ids)
@@ -154,4 +193,66 @@ do
     curl -X DELETE https://api.mullvad.net/accounts/v1/devices/$d_id -H "AUTHORIZATION:Bearer $access_token"
 done
 
-./runtests.sh
+#
+# Launch tests in all VMs
+#
+
+i=0
+testpids=""
+OSES=(debian11 windows10)
+
+for os in ${OSES[@]}; do
+
+    if [[ $i -gt 0 ]]; then
+        # Certain things are racey during setup, like obtaining a pty.
+        sleep 5
+    fi
+
+    mkdir -p "$SCRIPT_DIR/.ci-logs"
+
+    run_tests_for_os $os &> "$SCRIPT_DIR/.ci-logs/${os}.log" &
+    testpids[$i]=$!
+
+    let "i=i+1"
+
+done
+
+#
+# Wait for them to finish
+#
+
+i=0
+failed_builds=0
+
+for os in ${OSES[@]}; do
+    pid=${testpids[$i]}
+
+    if wait -fn $pid; then
+        echo "**********************************"
+        echo "* TESTS SUCCEEDED FOR OS: $os"
+        echo "**********************************"
+    else
+        let "failed_builds=failed_builds+1"
+
+        echo "**********************************"
+        echo "* TESTS FAILED FOR OS: $os"
+        echo "* BEGIN LOGS"
+        echo "**********************************"
+        echo ""
+
+        cat "$SCRIPT_DIR/.ci-logs/${os}.log"
+
+        echo ""
+        echo "**********************************"
+        echo "* END LOGS FOR OS: $os"
+        echo "**********************************"
+    fi
+
+    echo ""
+    echo ""
+
+    let "i=i+1"
+
+done
+
+exit $failed_builds

--- a/ci-runtests.sh
+++ b/ci-runtests.sh
@@ -154,7 +154,6 @@ function run_tests_for_os {
     local target=$(get_target_for_os $os)
     local prev_filename=$(get_app_filename $OLD_APP_VERSION $target)
     local cur_filename=$(get_app_filename $NEW_APP_VERSION $target)
-    local target=""
 
     OS=$os \
     SKIP_COMPILATION=1 \
@@ -171,8 +170,8 @@ echo "**********************************"
 rm -f ${SCRIPT_DIR}/packages/*-dev-*
 
 for target in x86_64-unknown-linux-gnu x86_64-pc-windows-gnu; do
-    download_app_package $OLD_APP_VERSION $target
-    download_app_package $NEW_APP_VERSION $target
+    download_app_package $OLD_APP_VERSION $target || true
+    download_app_package $NEW_APP_VERSION $target || true
     TARGET=$target ./build.sh
 done
 

--- a/scripts/build-runner-image.sh
+++ b/scripts/build-runner-image.sh
@@ -27,14 +27,14 @@ case $TARGET in
         ;;
 esac
 
+echo "************************************************************"
+echo "* Preparing test runner image: $TARGET"
+echo "************************************************************"
+
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 mkdir -p "${SCRIPT_DIR}/../testrunner-images/"
 TEST_RUNNER_IMAGE_PATH="${SCRIPT_DIR}/../testrunner-images/${TEST_RUNNER_IMAGE_FILENAME}"
-
-echo "**********************************"
-echo "* Preparing test runner image"
-echo "**********************************"
 
 case $TARGET in
 
@@ -81,6 +81,6 @@ case $TARGET in
 
 esac
 
-echo "**********************************"
-echo "* Success!"
-echo "**********************************"
+echo "************************************************************"
+echo "* Success! Built test runner image: $TARGET"
+echo "************************************************************"

--- a/scripts/destroy-network.sh
+++ b/scripts/destroy-network.sh
@@ -19,6 +19,6 @@ SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 dnsmasq_pid=$(cat "${SCRIPT_DIR}/.dnsmasq.pid")
 if [[ $? -eq 0 ]]; then
-    kill -- ${dnsmasq_pid}
+    env kill -- ${dnsmasq_pid}
     rm -f "${SCRIPT_DIR}/.dnsmasq.pid"
 fi

--- a/systemd/README.md
+++ b/systemd/README.md
@@ -1,0 +1,13 @@
+# systemd service
+
+This directory contains an example systemd timer for running the tests nightly.
+
+To install a user service for the current user, just edit the `.timer` and `.service` files to use
+the settings you want. Then copy the `.service` and `.timer` files to `~/.config/systemd/user/`.
+
+Enable the timer:
+
+```
+systemctl --user start mullvadvpn-app-tests.timer && \
+systemctl --user enable mullvadvpn-app-tests.timer
+```

--- a/systemd/mullvadvpn-app-tests.service
+++ b/systemd/mullvadvpn-app-tests.service
@@ -1,0 +1,11 @@
+# Systemd unit for running app tests and sending a status report
+# to the given set of email addresses.
+#
+[Unit]
+Description="Mullvad VPN app tests"
+
+[Service]
+Type=oneshot
+ExecStart=/home/test/mullvadvpn-app-tests/ci-runtests-and-report.sh
+Environment="ACCOUNT_TOKEN=XXXXXXXXXXXXXX"
+Environment="RECIPIENT_EMAIL_ADDRS=example1@email.addr,example2@email.addr"

--- a/systemd/mullvadvpn-app-tests.timer
+++ b/systemd/mullvadvpn-app-tests.timer
@@ -1,0 +1,11 @@
+# Run app tests once per day.
+#
+[Unit]
+Description="Run Mullvad VPN app tests"
+
+[Timer]
+OnCalendar=daily
+Persistent=true
+
+[Install]
+WantedBy=timers.target

--- a/test-runner/src/net.rs
+++ b/test-runner/src/net.rs
@@ -256,7 +256,7 @@ fn result_from_output(action: &'static str, output: Output) -> Result<(), ()> {
     let stderr_str = std::str::from_utf8(&output.stderr).unwrap_or("non-utf8 string");
 
     log::error!(
-        "{action} failed:\n\ncode: {:?}\n\nstdout:\n\n{}\n\nstderr\n\n{}",
+        "{action} failed:\n\ncode: {:?}\n\nstdout:\n\n{}\n\nstderr:\n\n{}",
         output.status.code(),
         stdout_str,
         stderr_str

--- a/test-runner/src/package.rs
+++ b/test-runner/src/package.rs
@@ -129,7 +129,7 @@ fn result_from_output(action: &'static str, output: Output) -> Result<()> {
     let stderr_str = std::str::from_utf8(&output.stderr).unwrap_or("non-utf8 string");
 
     log::error!(
-        "{action} failed:\n\nstdout:\n\n{}\n\nstderr\n\n{}",
+        "{action} failed:\n\nstdout:\n\n{}\n\nstderr:\n\n{}",
         stdout_str,
         stderr_str
     );


### PR DESCRIPTION
Includes a bunch of changes, but mainly:
* Test latest master against the version specified in `./dist-assets/desktop-product-version.txt` in the main app repo.
* Add a script for sending email reports after running the tests.
* Add a systemd timer example.
* Fix issue with `dnsmasq` not being killed.
* Switch from testing `TARGET`s to OSes, since the test runner image may be shared between different OS images.
* Return proper exit code from `test-manager`.