### PR TITLE
Ignore partial frames

### DIFF
--- a/test-rpc/src/transport.rs
+++ b/test-rpc/src/transport.rs
@@ -320,6 +320,13 @@ impl Decoder for MultiplexCodec {
     type Error = io::Error;
 
     fn decode(&mut self, src: &mut BytesMut) -> Result<Option<Self::Item>, Self::Error> {
+        while src.len() >= 2 && src[0] == b'^' {
+            // The test runner likes to send ^@ once in while. Unclear why,
+            // but it probably occurs (sometimes) when it reconnects to the
+            // serial device. Ignoring these control characters is safe.
+            log::debug!("ignoring control character");
+            src.advance(2);
+        }
         let frame = self.len_delim_codec.decode(src)?;
         frame.map(Self::decode_frame).transpose()
     }

--- a/test-rpc/src/transport.rs
+++ b/test-rpc/src/transport.rs
@@ -122,10 +122,10 @@ pub async fn create_client_transports(
 
     let handshake_task = tokio::spawn(async move {
         loop {
+            tokio::time::sleep(Duration::from_secs(5)).await;
             if handshake_tx_2.unbounded_send(()).is_err() {
                 break;
             }
-            tokio::time::sleep(Duration::from_secs(1)).await;
         }
     });
 

--- a/test-runner/src/main.rs
+++ b/test-runner/src/main.rs
@@ -2,7 +2,8 @@ use futures::{pin_mut, SinkExt, StreamExt};
 use logging::LOGGER;
 use std::{
     net::{IpAddr, SocketAddr},
-    path::Path, time::Duration,
+    path::Path,
+    time::Duration,
 };
 
 use tarpc::context;
@@ -195,7 +196,9 @@ async fn main() -> Result<(), Error> {
 
         log::info!("Running server");
 
-        tokio::spawn(foward_to_mullvad_daemon_interface(mullvad_daemon_transport));
+        tokio::spawn(forward_to_mullvad_daemon_interface(
+            mullvad_daemon_transport,
+        ));
 
         let server = tarpc::server::BaseChannel::with_defaults(runner_transport);
         server.execute(TestServer(()).serve()).await;
@@ -220,7 +223,7 @@ async fn discard_partial_frames(serial_stream: &mut tokio_serial::SerialStream) 
 }
 
 /// Forward data between the test manager and Mullvad management interface socket
-async fn foward_to_mullvad_daemon_interface(proxy_transport: GrpcForwarder) {
+async fn forward_to_mullvad_daemon_interface(proxy_transport: GrpcForwarder) {
     const IPC_READ_BUF_SIZE: usize = 16 * 1024;
 
     let mut srv_read_buf = [0u8; IPC_READ_BUF_SIZE];


### PR DESCRIPTION
The server receives partial frames when the manager sends data too early, causing the server to restart and occasionally the test manager to fail.