### PR TITLE
Add Fedora, Ubuntu, and Windows 11 targets

### DIFF
--- a/BUILD_OS_IMAGE.md
+++ b/BUILD_OS_IMAGE.md
@@ -12,7 +12,7 @@ On the host, start by creating a disk image and installing Debian on it:
 wget https://cdimage.debian.org/debian-cd/current/amd64/iso-cd/debian-11.5.0-amd64-netinst.iso
 mkdir -p os-images
 qemu-img create -f qcow2 ./os-images/debian.qcow2 5G
-qemu-system-x86_64 -cpu host -accel kvm -m 2048 -smp 2 -cdrom debian-11.5.0-amd64-netinst.iso -drive file=./os-images/debian.qcow2
+qemu-system-x86_64 -cpu host -accel kvm -m 4096 -smp 2 -cdrom debian-11.5.0-amd64-netinst.iso -drive file=./os-images/debian.qcow2
 ```
 
 ## Bootstrapping test runner
@@ -44,17 +44,75 @@ boot.
 
 * Enable the service: `systemctl enable testrunner.service`.
 
-# Creating a base Windows 10 image
+# Creating a base Windows image
 
-* Download a Windows ISO: https://www.microsoft.com/software-download/windows10
+## Windows 10
+
+* Download a Windows 10 ISO: https://www.microsoft.com/software-download/windows10
 
 * On the host, create a new disk image and install Windows on it:
 
     ```
     mkdir -p os-images
     qemu-img create -f qcow2 ./os-images/windows10.qcow2 32G
-    qemu-system-x86_64 -cpu host -accel kvm -m 2048 -smp 2 -cdrom <YOUR ISO HERE> -drive file=./os-images/windows10.qcow2
+    qemu-system-x86_64 -cpu host -accel kvm -m 4096 -smp 2 -cdrom <YOUR ISO HERE> -drive file=./os-images/windows10.qcow2
     ```
+
+    (For Windows 11, see the notes below.)
+
+## Windows 11
+
+* Download an ISO: https://www.microsoft.com/software-download/windows11
+
+* Create a disk image with at least 64GB of space:
+
+    ```
+    mkdir -p os-images
+    qemu-img create -f qcow2 ./os-images/windows11.qcow2 64G
+    ```
+
+* Windows 11 requires a TPM as well as secure boot to be enabled (and thus UEFI). For TPM, use the
+  emulator SWTPM:
+
+    ```
+    mkdir -p .tpm
+    swtpm socket -t  --ctrl type=unixio,path=".tpm/tpmsock"  --tpmstate ".tpm" --tpm2 -d
+    ```
+
+* For UEFI, use OVMF, which is available in the `edk2-ovmf` package.
+
+  `OVMF_VARS` is used writeable UEFI variables. Copy it to the root directory:
+
+  ```
+  cp /usr/share/OVMF/OVMF_VARS.secboot.fd .
+  ```
+
+* Launch the VM and install Windows:
+
+  ```
+  qemu-system-x86_64 -cpu host -accel kvm -m 4096 -smp 2 -cdrom <YOUR ISO HERE> -drive file=./os-images/windows11.qcow2 \
+  -tpmdev emulator,id=tpm0,chardev=chrtpm -chardev socket,id=chrtpm,path=".tpm/tpmsock" -device tpm-tis,tpmdev=tpm0 \
+  -global driver=cfi.pflash01,property=secure,value=on \
+  -drive if=pflash,format=raw,unit=0,file=/usr/share/OVMF/OVMF_CODE.secboot.fd,readonly=on \
+  -drive if=pflash,format=raw,unit=1,file=./OVMF_VARS.secboot.fd \
+  -machine q35,smm=on
+  ```
+
+## Notes on local accounts
+
+Logging in on a Microsoft account should not be necessary. A local account is sufficient.
+
+If you are asked to log in and there is no option to create a local account, try to disconnect
+from the network before trying again:
+
+1. Press shift-F10 to open a command prompt.
+1. Type `ipconfig /release` and press enter.
+
+If you are forced to connect to a network during the install, and cannot opt to use a local account,
+do the following:
+
+1. Press shift-F10 to open a command prompt.
+1. Type `oobe\BypassNRO` and press enter.
 
 ## Bootstrapping test runner
 
@@ -64,10 +122,7 @@ This can be achieved as follows:
 * Restart the VM:
 
     ```
-    qemu-system-x86_64 -cpu host -accel kvm -m 2048 -smp 2 \
-        -drive file="./os-images/windows10.qcow2" \
-        -device nec-usb-xhci,id=xhci \
-        -device usb-storage,drive=runner,bus=xhci.0
+    qemu-system-x86_64 -cpu host -accel kvm -m 4096 -smp 2 -drive file="./os-images/windows10.qcow2"
     ```
 
 * In the guest admin `cmd`, add the test runner as a scheduled task:
@@ -90,6 +145,13 @@ This can be achieved as follows:
       Start > Settings > Update & Security > Windows Security > App & browser control.
 
     * Set "Check apps and files" to off.
+
+* (Windows 11) In the guest, disable Smart App Control
+
+    * Go to "Smart App Control" under
+      Start > Settings > Privacy & security > Windows Security > App & browser control.
+
+    * Set it to off.
 
 * Shut down without logging out.
 

--- a/BUILD_OS_IMAGE.md
+++ b/BUILD_OS_IMAGE.md
@@ -2,7 +2,9 @@ This document explains how to create base OS images and run test runners on them
 
 For macOS, the host machine must be macOS. All other platforms assume that the host is Linux.
 
-# Creating a base Debian image
+# Creating a base Linux image
+
+These instructions use Debian, but the process is pretty much the same for any other distribution.
 
 On the host, start by creating a disk image and installing Debian on it:
 
@@ -13,16 +15,10 @@ qemu-img create -f qcow2 ./os-images/debian.qcow2 5G
 qemu-system-x86_64 -cpu host -accel kvm -m 2048 -smp 2 -cdrom debian-11.5.0-amd64-netinst.iso -drive file=./os-images/debian.qcow2
 ```
 
-## Bootstrapping RPC server
+## Bootstrapping test runner
 
-The testing image needs to be mounted to `/opt/testing`, and the RPC server needs to be started on boot.
-This can be achieved as follows:
-
-* (If needed) start the VM:
-
-    ```
-    qemu-system-x86_64 -cpu host -accel kvm -m 2048 -smp 2 -drive file=./os-images/debian.qcow2
-    ```
+The testing image needs to be mounted to `/opt/testing`, and the test runner needs to be started on
+boot.
 
 * In the guest, create a mount point for the runner: `mkdir -p /opt/testing`.
 
@@ -33,7 +29,7 @@ This can be achieved as follows:
     /dev/sdb /opt/testing ext4 defaults 0 1
     ```
 
-* Create a systemd service that starts the RPC server, `/etc/systemd/system/testrunner.service`:
+* Create a systemd service that starts the test runner, `/etc/systemd/system/testrunner.service`:
 
     ```
     [Unit]
@@ -60,9 +56,9 @@ This can be achieved as follows:
     qemu-system-x86_64 -cpu host -accel kvm -m 2048 -smp 2 -cdrom <YOUR ISO HERE> -drive file=./os-images/windows10.qcow2
     ```
 
-## Bootstrapping RPC server
+## Bootstrapping test runner
 
-The RPC server needs to be started on boot, with the test runner image mounted at `E:`.
+The test runner needs to be started on boot, with the test runner image mounted at `E:`.
 This can be achieved as follows:
 
 * Restart the VM:
@@ -112,9 +108,10 @@ interface.
 
 * Launch the VM and complete the installation of macOS.
 
-## Bootstrapping RPC server
+## Bootstrapping test runner
 
-* In the guest, create a service that starts the RPC server, `/Library/LaunchDaemons/net.mullvad.testunner.plist`:
+* In the guest, create a service that starts the test runner,
+  `/Library/LaunchDaemons/net.mullvad.testunner.plist`:
 
     ```
     <?xml version="1.0" encoding="UTF-8"?>
@@ -152,5 +149,3 @@ interface.
 * Enable the service: `sudo launchctl load -w /Library/LaunchDaemons/net.mullvad.testunner.plist`
 
 * Shut down the guest.
-
-FIXME: Patch tokio-serial due to baud rate error

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -485,6 +485,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "dbus"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f8bcdd56d2e5c4ed26a529c5a9029f5db8290d433497506f958eae3be148eb6"
+dependencies = [
+ "libc",
+ "libdbus-sys",
+ "winapi",
+]
+
+[[package]]
 name = "der"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1163,6 +1174,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc7fcc620a3bff7cdd7a365be3376c97191aeaccc2a603e600951e452615bf89"
 
 [[package]]
+name = "libdbus-sys"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c185b5b7ad900923ef3a8ff594083d4d9b5aea80bb4f32b8342363138c0d456b"
+dependencies = [
+ "pkg-config",
+]
+
+[[package]]
 name = "libloading"
 version = "0.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1292,7 +1312,7 @@ dependencies = [
 [[package]]
 name = "mullvad-api"
 version = "0.0.0"
-source = "git+https://github.com/mullvad/mullvadvpn-app#6efde79b1ad73f235f56c17d2753343540c3da66"
+source = "git+https://github.com/mullvad/mullvadvpn-app#8d3c1761c2e3f744b883d52b71b51740cabf483a"
 dependencies = [
  "chrono",
  "err-derive",
@@ -1318,7 +1338,7 @@ dependencies = [
 [[package]]
 name = "mullvad-management-interface"
 version = "0.0.0"
-source = "git+https://github.com/mullvad/mullvadvpn-app#6efde79b1ad73f235f56c17d2753343540c3da66"
+source = "git+https://github.com/mullvad/mullvadvpn-app#8d3c1761c2e3f744b883d52b71b51740cabf483a"
 dependencies = [
  "chrono",
  "err-derive",
@@ -1364,7 +1384,7 @@ dependencies = [
 [[package]]
 name = "mullvad-paths"
 version = "0.0.0"
-source = "git+https://github.com/mullvad/mullvadvpn-app#6efde79b1ad73f235f56c17d2753343540c3da66"
+source = "git+https://github.com/mullvad/mullvadvpn-app#8d3c1761c2e3f744b883d52b71b51740cabf483a"
 dependencies = [
  "dirs-next",
  "err-derive",
@@ -1386,7 +1406,7 @@ dependencies = [
 [[package]]
 name = "mullvad-types"
 version = "0.0.0"
-source = "git+https://github.com/mullvad/mullvadvpn-app#6efde79b1ad73f235f56c17d2753343540c3da66"
+source = "git+https://github.com/mullvad/mullvadvpn-app#8d3c1761c2e3f744b883d52b71b51740cabf483a"
 dependencies = [
  "chrono",
  "err-derive",
@@ -1676,6 +1696,12 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "pkg-config"
+version = "0.3.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ac9a59f73473f1b8d852421e59e64809f025994837ef743615c6d0c5b305160"
 
 [[package]]
 name = "pnet_base"
@@ -2443,9 +2469,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "talpid-dbus"
+version = "0.0.0"
+source = "git+https://github.com/mullvad/mullvadvpn-app#8d3c1761c2e3f744b883d52b71b51740cabf483a"
+dependencies = [
+ "dbus",
+ "err-derive",
+ "lazy_static",
+ "libc",
+ "log",
+ "tokio",
+]
+
+[[package]]
+name = "talpid-platform-metadata"
+version = "0.0.0"
+source = "git+https://github.com/mullvad/mullvadvpn-app#8d3c1761c2e3f744b883d52b71b51740cabf483a"
+dependencies = [
+ "rs-release",
+ "talpid-dbus",
+ "windows-sys 0.42.0",
+]
+
+[[package]]
 name = "talpid-time"
 version = "0.0.0"
-source = "git+https://github.com/mullvad/mullvadvpn-app#6efde79b1ad73f235f56c17d2753343540c3da66"
+source = "git+https://github.com/mullvad/mullvadvpn-app#8d3c1761c2e3f744b883d52b71b51740cabf483a"
 dependencies = [
  "libc",
  "tokio",
@@ -2454,7 +2503,7 @@ dependencies = [
 [[package]]
 name = "talpid-types"
 version = "0.0.0"
-source = "git+https://github.com/mullvad/mullvadvpn-app#6efde79b1ad73f235f56c17d2753343540c3da66"
+source = "git+https://github.com/mullvad/mullvadvpn-app#8d3c1761c2e3f744b883d52b71b51740cabf483a"
 dependencies = [
  "base64",
  "err-derive",
@@ -2484,7 +2533,7 @@ dependencies = [
 [[package]]
 name = "talpid-windows-net"
 version = "0.0.0"
-source = "git+https://github.com/mullvad/mullvadvpn-app#6efde79b1ad73f235f56c17d2753343540c3da66"
+source = "git+https://github.com/mullvad/mullvadvpn-app#8d3c1761c2e3f744b883d52b71b51740cabf483a"
 dependencies = [
  "err-derive",
  "futures",
@@ -2615,11 +2664,13 @@ dependencies = [
  "mullvad-management-interface 0.0.0",
  "mullvad-paths 0.0.0",
  "nix 0.25.0",
+ "once_cell",
  "parity-tokio-ipc",
  "rs-release",
  "rustls-pemfile 0.2.1",
  "serde",
  "serde_json",
+ "talpid-platform-metadata",
  "talpid-windows-net",
  "tarpc",
  "test-rpc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2056,6 +2056,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rs-release"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4a874cf4a0b9bc283edaa65d81d62368b84b1a8e56196e4885ca4701fd49972"
+
+[[package]]
 name = "rustc_version"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2610,6 +2616,7 @@ dependencies = [
  "mullvad-paths 0.0.0",
  "nix 0.25.0",
  "parity-tokio-ipc",
+ "rs-release",
  "rustls-pemfile 0.2.1",
  "serde",
  "serde_json",

--- a/README.md
+++ b/README.md
@@ -48,6 +48,9 @@ To run the tests on ARM64 macOS (on a *macOS* host), use
 
 ## Environment variables
 
+* `ACCOUNT_TOKENS` - Comma-separated list of account numbers. Use instead of `ACCOUNT_TOKEN` for
+  `./ci-runtests.sh`. Uses round robin to select an account for each VM.
+
 * `ACCOUNT_TOKEN` - Must be set to a valid Mullvad account number since a lot of tests depend on
   the app being logged in.
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,8 @@ For macOS, the host machine must be macOS. All other platforms assume that the h
     dnf install git gcc protobuf-devel libpcap-devel qemu \
         glibc-static e2tools \
         mingw64-gcc mingw64-winpthreads-static mtools \
-        golang-github-rootless-containers-rootlesskit slirp4netns dnsmasq
+        golang-github-rootless-containers-rootlesskit slirp4netns dnsmasq \
+        dbus-devel pkgconf-pkg-config swtpm edk2-ovmf
 
     rustup target add x86_64-pc-windows-gnu
     ```

--- a/ci-runtests.sh
+++ b/ci-runtests.sh
@@ -17,7 +17,7 @@ commit=${commit:0:6}
 OLD_APP_VERSION=$(curl -f https://raw.githubusercontent.com/mullvad/mullvadvpn-app/${commit}/dist-assets/desktop-product-version.txt)
 NEW_APP_VERSION=${OLD_APP_VERSION}-dev-${commit}
 
-OSES=(debian11 ubuntu2204 fedora37 windows10 windows11)
+OSES=(debian11 ubuntu2004 ubuntu2204 fedora37 fedora36 windows10 windows11)
 
 echo "$NEW_APP_VERSION" > "$SCRIPT_DIR/.ci-logs/last-version.log"
 

--- a/ci-runtests.sh
+++ b/ci-runtests.sh
@@ -19,6 +19,16 @@ NEW_APP_VERSION=${OLD_APP_VERSION}-dev-${commit}
 
 OSES=(debian11 ubuntu2004 ubuntu2204 fedora37 fedora36 windows10 windows11)
 
+if [[ -n "${ACCOUNT_TOKENS+x}" ]]; then
+    IFS=',' read -ra tokens <<< "${ACCOUNT_TOKENS}"
+else
+    if [[ -z "${ACCOUNT_TOKEN+x}" ]]; then
+        echo "'ACCOUNT_TOKENS' or 'ACCOUNT_TOKEN' must be specified" 1>&2
+        exit 1
+    fi
+    tokens=("${ACCOUNT_TOKEN}")
+fi
+
 echo "$NEW_APP_VERSION" > "$SCRIPT_DIR/.ci-logs/last-version.log"
 
 rustup update
@@ -34,6 +44,12 @@ function nice_time {
     s=$SECONDS
     echo "\"$@\" completed in $(($s/60))m:$(($s%60))s"
     return $result
+}
+
+function account_token_from_index {
+    local index
+    index=$(( $1 % ${#tokens[@]} ))
+    echo ${tokens[$index]}
 }
 
 # Returns 0 if $1 is a development build. `BASH_REMATCH` contains match groups
@@ -179,7 +195,7 @@ echo "**********************************"
 rm -f ${SCRIPT_DIR}/packages/*-dev-*
 
 function build_test_runners {
-    for os in ${OSES[@]}; do
+    for os in "${OSES[@]}"; do
         nice_time download_app_package $OLD_APP_VERSION $os || true
         nice_time download_app_package $NEW_APP_VERSION $os || true
     done
@@ -197,14 +213,16 @@ echo "**********************************"
 cargo build -p test-manager
 
 echo "**********************************"
-echo "* Clear devices from account"
+echo "* Clear devices from accounts"
 echo "**********************************"
 
-access_token=$(curl -X POST https://api.mullvad.net/auth/v1/token -d "{\"account_number\":\"$ACCOUNT_TOKEN\"}" -H "Content-Type:application/json" | jq -r .access_token)
-device_ids=$(curl https://api.mullvad.net/accounts/v1/devices -H "AUTHORIZATION:Bearer $access_token" | jq -r '.[].id')
-for d_id in $(xargs <<< $device_ids)
-do
-    curl -X DELETE https://api.mullvad.net/accounts/v1/devices/$d_id -H "AUTHORIZATION:Bearer $access_token" &> /dev/null
+for account in "${tokens[@]}"; do
+    access_token=$(curl -X POST https://api.mullvad.net/auth/v1/token -d "{\"account_number\":\"$account\"}" -H "Content-Type:application/json" | jq -r .access_token)
+    device_ids=$(curl https://api.mullvad.net/accounts/v1/devices -H "AUTHORIZATION:Bearer $access_token" | jq -r '.[].id')
+    for d_id in $(xargs <<< $device_ids)
+    do
+        curl -X DELETE https://api.mullvad.net/accounts/v1/devices/$d_id -H "AUTHORIZATION:Bearer $access_token" &> /dev/null
+    done
 done
 
 #
@@ -218,7 +236,7 @@ echo "**********************************"
 i=0
 testjobs=""
 
-for os in ${OSES[@]}; do
+for os in "${OSES[@]}"; do
 
     if [[ $i -gt 0 ]]; then
         # Certain things are racey during setup, like obtaining a pty.
@@ -227,10 +245,12 @@ for os in ${OSES[@]}; do
 
     mkdir -p "$SCRIPT_DIR/.ci-logs"
 
-    nice_time run_tests_for_os $os &> "$SCRIPT_DIR/.ci-logs/${os}.log" &
-    testjobs[$i]=$!
+    token=$(account_token_from_index $i)
 
-    let "i=i+1"
+    ACCOUNT_TOKEN=$token nice_time run_tests_for_os "$os" &> "$SCRIPT_DIR/.ci-logs/${os}.log" &
+    testjobs[i]=$!
+
+    ((i=i+1))
 
 done
 
@@ -241,7 +261,7 @@ done
 i=0
 failed_builds=0
 
-for os in ${OSES[@]}; do
+for os in "${OSES[@]}"; do
     if wait -fn ${testjobs[$i]}; then
         echo "**********************************"
         echo "* TESTS SUCCEEDED FOR OS: $os"
@@ -267,7 +287,7 @@ for os in ${OSES[@]}; do
     echo ""
     echo ""
 
-    let "i=i+1"
+    ((i=i+1))
 done
 
 exit $failed_builds

--- a/runtests.sh
+++ b/runtests.sh
@@ -132,6 +132,10 @@ if [[ ${OS} == "windows11" ]]; then
 
     # Q35 supports secure boot
     MACHINE_ARGS="-machine q35,smm=on"
+else
+    TPM_ARGS=""
+    OVMF_ARGS=""
+    MACHINE_ARGS=""
 fi
 
 pty=$(python3 -<<END_SCRIPT
@@ -173,9 +177,9 @@ qemu-system-x86_64 -cpu host -accel kvm -m 4096 -smp 2 \
     -device usb-storage,drive=runner,bus=xhci.0 \
     -device virtio-serial-pci -serial pty \
     ${DISPLAY_ARG} \
-    ${TPM_ARGS:-""} \
-    ${OVMF_ARGS:-""} \
-    ${MACHINE_ARGS:-""} \
+    ${TPM_ARGS} \
+    ${OVMF_ARGS} \
+    ${MACHINE_ARGS} \
     -nic tap,ifname=${HOST_NET_INTERFACE},script=no,downscript=no &
 
 QEMU_PID=$!

--- a/runtests.sh
+++ b/runtests.sh
@@ -7,33 +7,15 @@ cd "$SCRIPT_DIR"
 
 case ${OS} in
 
-    "debian11")
+    debian11|ubuntu2004|ubuntu2204|fedora36|fedora37)
         export TARGET="x86_64-unknown-linux-gnu"
-        OSIMAGE=./os-images/debian11.qcow2
+        OSIMAGE=./os-images/${OS}.qcow2
         RUNNERIMAGE=./testrunner-images/linux-test-runner.img
         ;;
 
-    "ubuntu2204")
-        export TARGET="x86_64-unknown-linux-gnu"
-        OSIMAGE=./os-images/ubuntu2204.qcow2
-        RUNNERIMAGE=./testrunner-images/linux-test-runner.img
-        ;;
-
-    "fedora37")
-        export TARGET="x86_64-unknown-linux-gnu"
-        OSIMAGE=./os-images/fedora37.qcow2
-        RUNNERIMAGE=./testrunner-images/linux-test-runner.img
-        ;;
-
-    "windows10")
+    windows10|windows11)
         export TARGET="x86_64-pc-windows-gnu"
-        OSIMAGE=./os-images/windows10.qcow2
-        RUNNERIMAGE=./testrunner-images/windows-test-runner.img
-        ;;
-
-    "windows11")
-        export TARGET="x86_64-pc-windows-gnu"
-        OSIMAGE=./os-images/windows11.qcow2
+        OSIMAGE=./os-images/${OS}.qcow2
         RUNNERIMAGE=./testrunner-images/windows-test-runner.img
         ;;
 

--- a/runtests.sh
+++ b/runtests.sh
@@ -101,11 +101,38 @@ function trap_handler {
 
     if [[ -n ${DNSMASQ_PID+x} ]]; then
         echo "Killing dnsmasq: ${DNSMASQ_PID}"
-        env kill -- ${DNSMASQ_PID}
+        env kill -- ${DNSMASQ_PID} || true
+    fi
+
+    if [[ -n ${TPM_PID+x} ]]; then
+        env kill -- ${TPM_PID} || true
     fi
 }
 
 trap "trap_handler" EXIT TERM
+
+if [[ ${OS} == "windows11" ]]; then
+    # Windows 11 requires a TPM
+    tpm_dir=$(mktemp -d)
+    swtpm socket -t --ctrl type=unixio,path="$tpm_dir/tpmsock"  --tpmstate dir="$tpm_dir" --tpm2 &
+    TPM_PID=$!
+    TPM_ARGS="-tpmdev emulator,id=tpm0,chardev=chrtpm -chardev socket,id=chrtpm,path="$tpm_dir/tpmsock" -device tpm-tis,tpmdev=tpm0"
+
+    # Secure boot is also required
+    # So we need UEFI/OVMF
+    OVMF_VARS_FILENAME="OVMF_VARS.secboot.fd"
+    OVMF_VARS="$SCRIPT_DIR/$OVMF_VARS_FILENAME"
+    OVMF_CODE="/usr/share/OVMF/OVMF_CODE.secboot.fd"
+    if [[ ! -e $OVMF_VARS ]]; then
+        cp "/usr/share/OVMF/$OVMF_VARS_FILENAME" $OVMF_VARS
+    fi
+    OVMF_ARGS="-global driver=cfi.pflash01,property=secure,value=on \
+-drive if=pflash,format=raw,unit=0,file=${OVMF_CODE},readonly=on \
+-drive if=pflash,format=raw,unit=1,file=${OVMF_VARS}"
+
+    # Q35 supports secure boot
+    MACHINE_ARGS="-machine q35,smm=on"
+fi
 
 pty=$(python3 -<<END_SCRIPT
 import os
@@ -138,7 +165,7 @@ ip link set ${HOST_NET_INTERFACE} up
 
 echo "Launching guest VM"
 
-qemu-system-x86_64 -cpu host -accel kvm -m 2048 -smp 2 \
+qemu-system-x86_64 -cpu host -accel kvm -m 4096 -smp 2 \
     -snapshot \
     -drive file="${OSIMAGE}" \
     -drive if=none,id=runner,file="${RUNNERIMAGE}" \
@@ -146,6 +173,9 @@ qemu-system-x86_64 -cpu host -accel kvm -m 2048 -smp 2 \
     -device usb-storage,drive=runner,bus=xhci.0 \
     -device virtio-serial-pci -serial pty \
     ${DISPLAY_ARG} \
+    ${TPM_ARGS:-""} \
+    ${OVMF_ARGS:-""} \
+    ${MACHINE_ARGS:-""} \
     -nic tap,ifname=${HOST_NET_INTERFACE},script=no,downscript=no &
 
 QEMU_PID=$!

--- a/runtests.sh
+++ b/runtests.sh
@@ -13,9 +13,27 @@ case ${OS} in
         RUNNERIMAGE=./testrunner-images/linux-test-runner.img
         ;;
 
+    "ubuntu2204")
+        export TARGET="x86_64-unknown-linux-gnu"
+        OSIMAGE=./os-images/ubuntu2204.qcow2
+        RUNNERIMAGE=./testrunner-images/linux-test-runner.img
+        ;;
+
+    "fedora37")
+        export TARGET="x86_64-unknown-linux-gnu"
+        OSIMAGE=./os-images/fedora37.qcow2
+        RUNNERIMAGE=./testrunner-images/linux-test-runner.img
+        ;;
+
     "windows10")
         export TARGET="x86_64-pc-windows-gnu"
         OSIMAGE=./os-images/windows10.qcow2
+        RUNNERIMAGE=./testrunner-images/windows-test-runner.img
+        ;;
+
+    "windows11")
+        export TARGET="x86_64-pc-windows-gnu"
+        OSIMAGE=./os-images/windows11.qcow2
         RUNNERIMAGE=./testrunner-images/windows-test-runner.img
         ;;
 

--- a/scripts/build-runner-image.sh
+++ b/scripts/build-runner-image.sh
@@ -47,6 +47,7 @@ case $TARGET in
             "${TEST_RUNNER_IMAGE_PATH}:/"
         e2cp \
             "${SCRIPT_DIR}/../packages/"*.deb \
+            "${SCRIPT_DIR}/../packages/"*.rpm \
             "${TEST_RUNNER_IMAGE_PATH}:/"
         ;;
 

--- a/systemd/mullvadvpn-app-tests.service
+++ b/systemd/mullvadvpn-app-tests.service
@@ -7,5 +7,5 @@ Description="Mullvad VPN app tests"
 [Service]
 Type=oneshot
 ExecStart=/home/test/mullvadvpn-app-tests/ci-runtests-and-report.sh
-Environment="ACCOUNT_TOKEN=XXXXXXXXXXXXXX"
+Environment="ACCOUNT_TOKENS=TOKEN1,TOKEN2,TOKEN3"
 Environment="RECIPIENT_EMAIL_ADDRS=example1@email.addr,example2@email.addr"

--- a/test-manager/src/tests/helpers.rs
+++ b/test-manager/src/tests/helpers.rs
@@ -24,7 +24,7 @@ use talpid_types::net::{
 use tarpc::context;
 use test_rpc::{
     meta,
-    package::{Package, PackageType},
+    package::Package,
     Interface, ServiceClient,
 };
 use tokio::time::timeout;
@@ -85,11 +85,9 @@ macro_rules! get_possible_api_endpoints {
 pub async fn get_package_desc(rpc: &ServiceClient, name: &str) -> Result<Package, Error> {
     match rpc.get_os(context::current()).await.map_err(Error::Rpc)? {
         meta::Os::Linux => Ok(Package {
-            r#type: PackageType::Dpkg,
             path: Path::new(&format!("/opt/testing/{}", name)).to_path_buf(),
         }),
         meta::Os::Windows => Ok(Package {
-            r#type: PackageType::NsisExe,
             path: Path::new(&format!(r"E:\{}", name)).to_path_buf(),
         }),
         _ => unimplemented!(),

--- a/test-rpc/src/package.rs
+++ b/test-rpc/src/package.rs
@@ -33,19 +33,14 @@ pub enum Error {
 
     #[error(display = "Installer or uninstaller failed due to a signal")]
     InstallerFailedSignal,
+
+    #[error(display = "Unrecognized OS: {}", _0)]
+    UnknownOs(String),
 }
 
 pub type Result<T> = std::result::Result<T, Error>;
 
 #[derive(Debug, Deserialize, Serialize)]
 pub struct Package {
-    pub r#type: PackageType,
     pub path: PathBuf,
-}
-
-#[derive(Debug, Deserialize, Serialize)]
-pub enum PackageType {
-    Dpkg,
-    Rpm,
-    NsisExe,
 }

--- a/test-runner/Cargo.toml
+++ b/test-runner/Cargo.toml
@@ -11,6 +11,7 @@ tokio-serial = "5.4.1"
 err-derive = "0.3.1"
 log = "0.4.17"
 lazy_static = "1.4.0"
+once_cell = "1.16.0"
 parity-tokio-ipc = "0.9"
 bytes = "1.3.0"
 serde = { version = "1.0" }
@@ -25,6 +26,7 @@ mullvad-management-interface = { git = "https://github.com/mullvad/mullvadvpn-ap
 
 test-rpc = { path = "../test-rpc" }
 mullvad-paths = { git = "https://github.com/mullvad/mullvadvpn-app" }
+talpid-platform-metadata = { git = "https://github.com/mullvad/mullvadvpn-app" }
 
 [target."cfg(target_os=\"windows\")".dependencies]
 talpid-windows-net = { git = "https://github.com/mullvad/mullvadvpn-app" }

--- a/test-runner/Cargo.toml
+++ b/test-runner/Cargo.toml
@@ -36,3 +36,4 @@ default-features = false
 
 [target.'cfg(target_os = "linux")'.dependencies]
 nix = { version = "0.25", features = ["socket", "net"] }
+rs-release = "0.1.7"

--- a/test-runner/src/package.rs
+++ b/test-runner/src/package.rs
@@ -1,18 +1,19 @@
-// TODO: Fix terrible abstraction
-
 use std::{
     path::Path,
     process::{Output, Stdio},
 };
-use test_rpc::package::{Error, Package, PackageType, Result};
+use test_rpc::package::{Error, Package, Result};
 use tokio::process::Command;
+
 
 #[cfg(target_os = "linux")]
 pub async fn uninstall_app() -> Result<()> {
-    // TODO: Fedora
-    // TODO: Consider using: dpkg -r $(dpkg -f package.deb Package)
-    uninstall_dpkg("mullvad-vpn", true).await
+    match get_distribution()? {
+        Distribution::Debian | Distribution::Ubuntu => uninstall_dpkg("mullvad-vpn", true).await,
+        Distribution::Fedora => uninstall_rpm("mullvad-vpn").await,
+    }
 }
+
 #[cfg(target_os = "macos")]
 pub async fn uninstall_app() -> Result<()> {
     unimplemented!()
@@ -40,7 +41,7 @@ pub async fn uninstall_app() -> Result<()> {
     cmd.arg("/allusers");
     // Silent mode
     cmd.arg("/S");
-    // NSIS! Doesn't understand that it shouldn't fork itself unless
+    // NSIS doesn't understand that it shouldn't fork itself unless
     // there's whitespace prepended to "_?=".
     cmd.arg(format!(" _?={}", program_dir.display()));
     cmd.stdout(Stdio::piped());
@@ -54,14 +55,25 @@ pub async fn uninstall_app() -> Result<()> {
         .and_then(|output| result_from_output("uninstall app", output))
 }
 
+#[cfg(target_os = "windows")]
 pub async fn install_package(package: Package) -> Result<()> {
-    match package.r#type {
-        PackageType::Dpkg => install_dpkg(&package.path).await,
-        PackageType::Rpm => unimplemented!(),
-        PackageType::NsisExe => install_nsis_exe(&package.path).await,
+    install_nsis_exe(&package.path).await
+}
+
+#[cfg(target_os = "linux")]
+pub async fn install_package(package: Package) -> Result<()> {
+    match get_distribution()? {
+        Distribution::Debian | Distribution::Ubuntu => install_dpkg(&package.path).await,
+        Distribution::Fedora => install_rpm(&package.path).await,
     }
 }
 
+#[cfg(target_os = "macos")]
+pub async fn install_package(package: Package) -> Result<()> {
+    unimplemented!()
+}
+
+#[cfg(target_os = "linux")]
 async fn install_dpkg(path: &Path) -> Result<()> {
     let mut cmd = Command::new("/usr/bin/dpkg");
     cmd.arg("-i");
@@ -99,6 +111,38 @@ async fn uninstall_dpkg(name: &str, purge: bool) -> Result<()> {
         .and_then(|output| result_from_output(action, output))
 }
 
+#[cfg(target_os = "linux")]
+async fn install_rpm(path: &Path) -> Result<()> {
+    let mut cmd = Command::new("/usr/bin/dnf");
+    cmd.args(["install", "-y"]);
+    cmd.arg(path.as_os_str());
+    cmd.kill_on_drop(true);
+    cmd.stdout(Stdio::piped());
+    cmd.stderr(Stdio::piped());
+    cmd.spawn()
+        .map_err(|e| strip_error(Error::RunApp, e))?
+        .wait_with_output()
+        .await
+        .map_err(|e| strip_error(Error::RunApp, e))
+        .and_then(|output| result_from_output("dnf install", output))
+}
+
+#[cfg(target_os = "linux")]
+async fn uninstall_rpm(name: &str) -> Result<()> {
+    let mut cmd = Command::new("/usr/bin/dnf");
+    cmd.args(["remove", "-y", name]);
+    cmd.kill_on_drop(true);
+    cmd.stdout(Stdio::piped());
+    cmd.stderr(Stdio::piped());
+    cmd.spawn()
+        .map_err(|e| strip_error(Error::RunApp, e))?
+        .wait_with_output()
+        .await
+        .map_err(|e| strip_error(Error::RunApp, e))
+        .and_then(|output| result_from_output("dnf remove", output))
+}
+
+#[cfg(target_os = "windows")]
 async fn install_nsis_exe(path: &Path) -> Result<()> {
     let mut cmd = Command::new(path);
 
@@ -113,6 +157,24 @@ async fn install_nsis_exe(path: &Path) -> Result<()> {
         .await
         .map_err(|e| strip_error(Error::RunApp, e))
         .and_then(|output| result_from_output("install app", output))
+}
+
+#[cfg(target_os = "linux")]
+enum Distribution {
+    Debian,
+    Ubuntu,
+    Fedora,
+}
+
+#[cfg(target_os = "linux")]
+fn get_distribution() -> Result<Distribution> {
+    let os_release = rs_release::get_os_release().map_err(|_error| Error::UnknownOs("unknown".to_string()))?;
+    match os_release.get("id").or(os_release.get("ID")).ok_or(Error::UnknownOs("unknown".to_string()))?.as_str() {
+        "debian" => Ok(Distribution::Debian),
+        "ubuntu" => Ok(Distribution::Ubuntu),
+        "fedora" => Ok(Distribution::Fedora),
+        os => Err(Error::UnknownOs(os.to_string())),
+    }
 }
 
 fn strip_error<T: std::error::Error>(error: Error, source: T) -> Error {

--- a/test-runner/src/package.rs
+++ b/test-runner/src/package.rs
@@ -1,7 +1,6 @@
 // TODO: Fix terrible abstraction
 
 use std::{
-    ffi::OsStr,
     path::Path,
     process::{Output, Stdio},
 };
@@ -65,7 +64,8 @@ pub async fn install_package(package: Package) -> Result<()> {
 
 async fn install_dpkg(path: &Path) -> Result<()> {
     let mut cmd = Command::new("/usr/bin/dpkg");
-    cmd.args([OsStr::new("-i"), path.as_os_str()]);
+    cmd.arg("-i");
+    cmd.arg(path.as_os_str());
     cmd.kill_on_drop(true);
     cmd.stdout(Stdio::piped());
     cmd.stderr(Stdio::piped());


### PR DESCRIPTION
Main changes:

* Ubuntu requires no changes. For Fedora, the package installer has just been updated to support DNF/RPMs.
* For Windows 11, as secure boot and a TPM are required, the scripts/instructions have been updated to include a TPM emulator and OVMF.
* Ignore any console output to the serial port during boot.