### PR TITLE
Allow multiple account tokens to be specified with 'ACCOUNT_TOKENS'

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,9 @@ To run the tests on ARM64 macOS (on a *macOS* host), use
 
 ## Environment variables
 
+* `ACCOUNT_TOKENS` - Comma-separated list of account numbers. Use instead of `ACCOUNT_TOKEN` for
+  `./ci-runtests.sh`. Uses round robin to select an account for each VM.
+
 * `ACCOUNT_TOKEN` - Must be set to a valid Mullvad account number since a lot of tests depend on
   the app being logged in.
 

--- a/systemd/mullvadvpn-app-tests.service
+++ b/systemd/mullvadvpn-app-tests.service
@@ -7,5 +7,5 @@ Description="Mullvad VPN app tests"
 [Service]
 Type=oneshot
 ExecStart=/home/test/mullvadvpn-app-tests/ci-runtests-and-report.sh
-Environment="ACCOUNT_TOKEN=XXXXXXXXXXXXXX"
+Environment="ACCOUNT_TOKENS=TOKEN1,TOKEN2,TOKEN3"
 Environment="RECIPIENT_EMAIL_ADDRS=example1@email.addr,example2@email.addr"


### PR DESCRIPTION
Make it possible to specify multiple tokens. This is necessary for testing >5 OSes.