### PR TITLE
Add retry logic to exit relay tests

### DIFF
--- a/test-manager/src/tests/mod.rs
+++ b/test-manager/src/tests/mod.rs
@@ -28,6 +28,9 @@ pub enum Error {
     #[error(display = "Failed to ping destination")]
     PingFailed,
 
+    #[error(display = "geoip lookup failed")]
+    GeoipError(test_rpc::Error),
+
     #[error(display = "Package action failed")]
     Package(&'static str, test_rpc::package::Error),
 

--- a/test-manager/src/tests/tunnel.rs
+++ b/test-manager/src/tests/tunnel.rs
@@ -1,5 +1,6 @@
 use super::helpers::{
-    connect_and_wait, disconnect_and_wait, ping_with_timeout, update_relay_settings,
+    connect_and_wait, disconnect_and_wait, geoip_lookup_with_retries, ping_with_timeout,
+    update_relay_settings,
 };
 use super::Error;
 
@@ -273,12 +274,7 @@ pub async fn test_bridge(
 
     log::info!("Verifying exit server");
 
-    let geoip = rpc
-        .geoip_lookup(context::current())
-        .await
-        .expect("geoip lookup failed")
-        .expect("geoip lookup failed");
-
+    let geoip = geoip_lookup_with_retries(rpc).await?;
     assert_eq!(geoip.mullvad_exit_ip_hostname, EXPECTED_EXIT_HOSTNAME);
 
     disconnect_and_wait(&mut mullvad_client).await?;
@@ -355,12 +351,7 @@ pub async fn test_multihop(
 
     log::info!("Verifying exit server");
 
-    let geoip = rpc
-        .geoip_lookup(context::current())
-        .await
-        .expect("geoip lookup failed")
-        .expect("geoip lookup failed");
-
+    let geoip = geoip_lookup_with_retries(rpc).await?;
     assert_eq!(geoip.mullvad_exit_ip_hostname, EXPECTED_EXIT_HOSTNAME);
 
     disconnect_and_wait(&mut mullvad_client).await?;

--- a/test-runner/src/net.rs
+++ b/test-runner/src/net.rs
@@ -249,7 +249,8 @@ fn non_tunnel_interface() -> &'static str {
     use talpid_platform_metadata::WindowsVersion;
 
     static WINDOWS_VERSION: OnceCell<WindowsVersion> = OnceCell::new();
-    let version = WINDOWS_VERSION.get_or_init(|| WindowsVersion::new().expect("failed to obtain Windows version"));
+    let version = WINDOWS_VERSION
+        .get_or_init(|| WindowsVersion::new().expect("failed to obtain Windows version"));
 
     if version.build_number() >= 22000 {
         // Windows 11

--- a/test-runner/src/package.rs
+++ b/test-runner/src/package.rs
@@ -5,7 +5,6 @@ use std::{
 use test_rpc::package::{Error, Package, Result};
 use tokio::process::Command;
 
-
 #[cfg(target_os = "linux")]
 pub async fn uninstall_app() -> Result<()> {
     match get_distribution()? {
@@ -168,8 +167,14 @@ enum Distribution {
 
 #[cfg(target_os = "linux")]
 fn get_distribution() -> Result<Distribution> {
-    let os_release = rs_release::get_os_release().map_err(|_error| Error::UnknownOs("unknown".to_string()))?;
-    match os_release.get("id").or(os_release.get("ID")).ok_or(Error::UnknownOs("unknown".to_string()))?.as_str() {
+    let os_release =
+        rs_release::get_os_release().map_err(|_error| Error::UnknownOs("unknown".to_string()))?;
+    match os_release
+        .get("id")
+        .or(os_release.get("ID"))
+        .ok_or(Error::UnknownOs("unknown".to_string()))?
+        .as_str()
+    {
         "debian" => Ok(Distribution::Debian),
         "ubuntu" => Ok(Distribution::Ubuntu),
         "fedora" => Ok(Distribution::Fedora),


### PR DESCRIPTION
The exit relay is verified in some tests using `am.i.mullvad.net`, but this tends to fail very often. This PR simply adds some retry logic to reduce the number of spurious errors.