### PR TITLE
Build test runner in container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,6 @@
+FROM debian:stable
+
+RUN apt-get update && apt-get install -y \
+    gcc curl libdbus-1-dev protobuf-compiler
+RUN curl https://sh.rustup.rs -sSf | sh -s -- -y
+ENV PATH="/root/.cargo/bin:${PATH}"

--- a/README.md
+++ b/README.md
@@ -27,8 +27,7 @@ For macOS, the host machine must be macOS. All other platforms assume that the h
 
     ```
     dnf install git gcc protobuf-devel libpcap-devel qemu \
-        glibc-static e2tools \
-        mingw64-gcc mingw64-winpthreads-static mtools \
+        podman e2tools mingw64-gcc mingw64-winpthreads-static mtools \
         golang-github-rootless-containers-rootlesskit slirp4netns dnsmasq \
         dbus-devel pkgconf-pkg-config swtpm edk2-ovmf
 

--- a/build.sh
+++ b/build.sh
@@ -2,6 +2,21 @@
 
 set -eu
 
-RUSTFLAGS="-C target-feature=+crt-static" cargo build --bin test-runner --release --target "${TARGET}"
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+cd "$SCRIPT_DIR"
+
+if [[ $TARGET == x86_64-unknown-linux-gnu ]]; then
+    mkdir -p .container/cargo-registry
+    podman build -t mullvadvpn-app-tests .
+
+    podman run \
+        -v "$PWD/.container/cargo-registry":/root/.cargo/registry \
+        -v "$PWD":/src:Z \
+        -e CARGO_HOME=/root/.cargo/registry \
+        mullvadvpn-app-tests \
+        /bin/bash -c "cd /src/; cargo build --bin test-runner --release --target ${TARGET}"
+else
+    RUSTFLAGS="-C target-feature=+crt-static" cargo build --bin test-runner --release --target "${TARGET}"
+fi
 
 ./scripts/build-runner-image.sh

--- a/runtests.sh
+++ b/runtests.sh
@@ -41,17 +41,17 @@ else
     DISPLAY_ARG=""
 fi
 
-if [[ "$TARGET" != *-darwin && "$EUID" -ne 0 ]]; then
-    echo "Using rootlesskit since uid != 0"
-    rootlesskit --net slirp4netns --disable-host-loopback --copy-up=/etc "${BASH_SOURCE[0]}" "$@"
-    exit 0
-fi
-
 if [[ -z "${SKIP_COMPILATION+x}" ]]; then
     ./build.sh
 
     echo "Compiling tests"
     cargo build -p test-manager
+fi
+
+if [[ "$TARGET" != *-darwin && "$EUID" -ne 0 ]]; then
+    echo "Using rootlesskit since uid != 0"
+    SKIP_COMPILATION=1 rootlesskit --net slirp4netns --disable-host-loopback --copy-up=/etc "${BASH_SOURCE[0]}" "$@"
+    exit 0
 fi
 
 function run_tests {

--- a/runtests.sh
+++ b/runtests.sh
@@ -100,6 +100,12 @@ if [[ ${OS} == "windows11" ]]; then
     TPM_PID=$!
     TPM_ARGS="-tpmdev emulator,id=tpm0,chardev=chrtpm -chardev socket,id=chrtpm,path="$tpm_dir/tpmsock" -device tpm-tis,tpmdev=tpm0"
 
+    wait_fd_count=0
+    while [[ ! -e "$tpm_dir/tpmsock" && wait_fd_count -lt 15 ]]; do
+        ((wait_fd_count=wait_fd_count+1))
+        sleep 1
+    done
+
     # Secure boot is also required
     # So we need UEFI/OVMF
     OVMF_VARS_FILENAME="OVMF_VARS.secboot.fd"

--- a/test-manager/src/tests/mod.rs
+++ b/test-manager/src/tests/mod.rs
@@ -28,6 +28,9 @@ pub enum Error {
     #[error(display = "Failed to ping destination")]
     PingFailed,
 
+    #[error(display = "geoip lookup failed")]
+    GeoipError(test_rpc::Error),
+
     #[error(display = "Package action failed")]
     Package(&'static str, test_rpc::package::Error),
 

--- a/test-manager/src/tests/tunnel.rs
+++ b/test-manager/src/tests/tunnel.rs
@@ -1,5 +1,6 @@
 use super::helpers::{
-    connect_and_wait, disconnect_and_wait, ping_with_timeout, update_relay_settings,
+    connect_and_wait, disconnect_and_wait, geoip_lookup_with_retries, ping_with_timeout,
+    update_relay_settings,
 };
 use super::Error;
 
@@ -273,12 +274,7 @@ pub async fn test_bridge(
 
     log::info!("Verifying exit server");
 
-    let geoip = rpc
-        .geoip_lookup(context::current())
-        .await
-        .expect("geoip lookup failed")
-        .expect("geoip lookup failed");
-
+    let geoip = geoip_lookup_with_retries(rpc).await?;
     assert_eq!(geoip.mullvad_exit_ip_hostname, EXPECTED_EXIT_HOSTNAME);
 
     disconnect_and_wait(&mut mullvad_client).await?;
@@ -355,12 +351,7 @@ pub async fn test_multihop(
 
     log::info!("Verifying exit server");
 
-    let geoip = rpc
-        .geoip_lookup(context::current())
-        .await
-        .expect("geoip lookup failed")
-        .expect("geoip lookup failed");
-
+    let geoip = geoip_lookup_with_retries(rpc).await?;
     assert_eq!(geoip.mullvad_exit_ip_hostname, EXPECTED_EXIT_HOSTNAME);
 
     disconnect_and_wait(&mut mullvad_client).await?;

--- a/test-rpc/src/transport.rs
+++ b/test-rpc/src/transport.rs
@@ -336,10 +336,10 @@ impl MultiplexCodec {
                 continue;
             }
             if !self.has_connected {
-                for (pos, pair) in src.windows(2).enumerate() {
-                    if pair == b"\r\n" {
-                        log::debug!("ignoring newline");
-                        src.advance(pos + 2);
+                for (pos, c) in src.iter().rev().enumerate() {
+                    if *c == b'\n' {
+                        log::debug!("ignoring newlines");
+                        src.advance(src.len() - pos);
                         break;
                     }
                 }

--- a/test-runner/src/net.rs
+++ b/test-runner/src/net.rs
@@ -249,7 +249,8 @@ fn non_tunnel_interface() -> &'static str {
     use talpid_platform_metadata::WindowsVersion;
 
     static WINDOWS_VERSION: OnceCell<WindowsVersion> = OnceCell::new();
-    let version = WINDOWS_VERSION.get_or_init(|| WindowsVersion::new().expect("failed to obtain Windows version"));
+    let version = WINDOWS_VERSION
+        .get_or_init(|| WindowsVersion::new().expect("failed to obtain Windows version"));
 
     if version.build_number() >= 22000 {
         // Windows 11

--- a/test-runner/src/package.rs
+++ b/test-runner/src/package.rs
@@ -5,7 +5,6 @@ use std::{
 use test_rpc::package::{Error, Package, Result};
 use tokio::process::Command;
 
-
 #[cfg(target_os = "linux")]
 pub async fn uninstall_app() -> Result<()> {
     match get_distribution()? {
@@ -194,8 +193,14 @@ enum Distribution {
 
 #[cfg(target_os = "linux")]
 fn get_distribution() -> Result<Distribution> {
-    let os_release = rs_release::get_os_release().map_err(|_error| Error::UnknownOs("unknown".to_string()))?;
-    match os_release.get("id").or(os_release.get("ID")).ok_or(Error::UnknownOs("unknown".to_string()))?.as_str() {
+    let os_release =
+        rs_release::get_os_release().map_err(|_error| Error::UnknownOs("unknown".to_string()))?;
+    match os_release
+        .get("id")
+        .or(os_release.get("ID"))
+        .ok_or(Error::UnknownOs("unknown".to_string()))?
+        .as_str()
+    {
         "debian" => Ok(Distribution::Debian),
         "ubuntu" => Ok(Distribution::Ubuntu),
         "fedora" => Ok(Distribution::Fedora),


### PR DESCRIPTION
Changes:
* Fix the problem we have due to statically linking to glibc. We build in a container instead.
* Add retries to `am.i.mullvad.net` queries.
* Skip newlines (not CRLF) before receiving initial message/ping. This may still be brittle and the initial frame should possibly be replaced by a magic number/identifier.
* Wait for error state before upgrading instead of relying on timing.