### PR TITLE
Add RPC client wrapper

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2637,6 +2637,7 @@ dependencies = [
 name = "test-rpc"
 version = "0.1.0"
 dependencies = [
+ "async-trait",
  "bytes",
  "colored",
  "err-derive",

--- a/test-manager/src/logging.rs
+++ b/test-manager/src/logging.rs
@@ -3,7 +3,6 @@ use colored::Colorize;
 use futures::FutureExt;
 use std::future::Future;
 use std::panic;
-use tarpc::context;
 use test_rpc::{
     logging::{LogOutput, Output},
     ServiceClient,
@@ -92,7 +91,7 @@ where
     F: Fn(ServiceClient, MullvadClient) -> R,
     R: Future<Output = Result<(), Error>>,
 {
-    let _flushed = runner_rpc.try_poll_output(context::current()).await;
+    let _flushed = runner_rpc.try_poll_output().await;
 
     // Assert that the test is unwind safe, this is the same assertion that cargo tests do. This
     // assertion being incorrect can not lead to memory unsafety however it could theoretically
@@ -104,10 +103,7 @@ where
 
     let mut output = vec![];
     if matches!(result, Ok(Err(_)) | Err(_)) {
-        let output_after_test = runner_rpc
-            .try_poll_output(context::current())
-            .await
-            .map_err(Error::Rpc)?;
+        let output_after_test = runner_rpc.try_poll_output().await;
         match output_after_test {
             Ok(mut output_after_test) => {
                 output.append(&mut output_after_test);
@@ -118,7 +114,7 @@ where
         }
     }
     let log_output = runner_rpc
-        .get_mullvad_app_logs(context::current())
+        .get_mullvad_app_logs()
         .await
         .map_err(Error::Rpc)?;
 

--- a/test-manager/src/tests/mod.rs
+++ b/test-manager/src/tests/mod.rs
@@ -19,7 +19,7 @@ const WAIT_FOR_TUNNEL_STATE_TIMEOUT: Duration = Duration::from_secs(20);
 #[derive(err_derive::Error, Debug, PartialEq, Eq)]
 pub enum Error {
     #[error(display = "RPC call failed")]
-    Rpc(#[source] tarpc::client::RpcError),
+    Rpc(#[source] test_rpc::Error),
 
     #[error(display = "Timeout waiting for ping")]
     PingTimeout,
@@ -29,9 +29,6 @@ pub enum Error {
 
     #[error(display = "geoip lookup failed")]
     GeoipError(test_rpc::Error),
-
-    #[error(display = "Package action failed")]
-    Package(&'static str, test_rpc::package::Error),
 
     #[error(display = "Found running daemon unexpectedly")]
     DaemonRunning,
@@ -43,7 +40,7 @@ pub enum Error {
     DaemonError(String),
 
     #[error(display = "Logging caused an error: {}", _0)]
-    Log(test_rpc::logging::Error),
+    Log(test_rpc::Error),
 }
 
 static DEFAULT_SETTINGS: OnceCell<Settings> = OnceCell::new();

--- a/test-manager/src/tests/tunnel.rs
+++ b/test-manager/src/tests/tunnel.rs
@@ -14,7 +14,6 @@ use mullvad_types::relay_constraints::{
 use pnet_packet::ip::IpNextHeaderProtocols;
 use std::net::{IpAddr, Ipv4Addr};
 use talpid_types::net::{TransportProtocol, TunnelType};
-use tarpc::context;
 use test_macro::test_function;
 use test_rpc::{Interface, ServiceClient};
 
@@ -158,8 +157,8 @@ pub async fn test_udp2tcp_tunnel(
     //
 
     let guest_ip = rpc
-        .get_interface_ip(context::current(), Interface::NonTunnel)
-        .await?
+        .get_interface_ip(Interface::NonTunnel)
+        .await
         .expect("failed to obtain inet interface IP");
 
     let monitor = start_packet_monitor(

--- a/test-rpc/Cargo.toml
+++ b/test-rpc/Cargo.toml
@@ -15,6 +15,7 @@ bytes = "1.3.0"
 err-derive = "0.3.1"
 log = "0.4.17"
 colored = "2.0.0"
+async-trait = "0.1.58"
 
 [dependencies.tokio-util]
 version = "0.7"

--- a/test-rpc/src/client.rs
+++ b/test-rpc/src/client.rs
@@ -1,0 +1,140 @@
+use std::time::{Duration, SystemTime};
+
+use super::*;
+
+const INSTALL_TIMEOUT: Duration = Duration::from_secs(300);
+
+#[derive(Debug, Clone)]
+pub struct ServiceClient {
+    client: service::ServiceClient,
+}
+
+// TODO: implement wrapper methods using macro on Service trait
+
+impl ServiceClient {
+    pub fn new(
+        transport: tarpc::transport::channel::UnboundedChannel<
+            tarpc::Response<service::ServiceResponse>,
+            tarpc::ClientMessage<service::ServiceRequest>,
+        >,
+    ) -> Self {
+        Self {
+            client: super::service::ServiceClient::new(tarpc::client::Config::default(), transport)
+                .spawn(),
+        }
+    }
+
+    /// Install app package.
+    pub async fn install_app(&self, package_path: package::Package) -> Result<(), Error> {
+        let mut ctx = tarpc::context::current();
+        ctx.deadline = SystemTime::now().checked_add(INSTALL_TIMEOUT).unwrap();
+
+        self.client
+            .install_app(ctx, package_path)
+            .await
+            .map_err(Error::Tarpc)?
+    }
+
+    /// Remove app package.
+    pub async fn uninstall_app(&self) -> Result<(), Error> {
+        let mut ctx = tarpc::context::current();
+        ctx.deadline = SystemTime::now().checked_add(INSTALL_TIMEOUT).unwrap();
+
+        self.client.uninstall_app(ctx).await?
+    }
+
+    /// Get the output of the runners stdout logs since the last time this function was called.
+    /// Block if there is no output until some output is provided by the runner.
+    pub async fn poll_output(&self) -> Result<Vec<logging::Output>, Error> {
+        self.client.poll_output(tarpc::context::current()).await?
+    }
+
+    /// Get the output of the runners stdout logs since the last time this function was called.
+    /// Block if there is no output until some output is provided by the runner.
+    pub async fn try_poll_output(&self) -> Result<Vec<logging::Output>, Error> {
+        self.client
+            .try_poll_output(tarpc::context::current())
+            .await?
+    }
+
+    pub async fn get_mullvad_app_logs(&self) -> Result<logging::LogOutput, Error> {
+        self.client
+            .get_mullvad_app_logs(tarpc::context::current())
+            .await
+            .map_err(Error::Tarpc)
+    }
+
+    /// Return the OS of the guest.
+    pub async fn get_os(&self) -> Result<meta::Os, Error> {
+        self.client
+            .get_os(tarpc::context::current())
+            .await
+            .map_err(Error::Tarpc)
+    }
+
+    /// Return status of the system service.
+    pub async fn mullvad_daemon_get_status(&self) -> Result<mullvad_daemon::ServiceStatus, Error> {
+        self.client
+            .mullvad_daemon_get_status(tarpc::context::current())
+            .await
+            .map_err(Error::Tarpc)
+    }
+
+    /// Returns all Mullvad app files, directories, and other data found on the system.
+    pub async fn find_mullvad_app_traces(&self) -> Result<Vec<AppTrace>, Error> {
+        self.client
+            .find_mullvad_app_traces(tarpc::context::current())
+            .await?
+    }
+
+    /// Send TCP packet
+    pub async fn send_tcp(
+        &self,
+        bind_addr: SocketAddr,
+        destination: SocketAddr,
+    ) -> Result<(), Error> {
+        self.client
+            .send_tcp(tarpc::context::current(), bind_addr, destination)
+            .await?
+    }
+
+    /// Send UDP packet
+    pub async fn send_udp(
+        &self,
+        bind_addr: SocketAddr,
+        destination: SocketAddr,
+    ) -> Result<(), Error> {
+        self.client
+            .send_udp(tarpc::context::current(), bind_addr, destination)
+            .await?
+    }
+
+    /// Send ICMP
+    pub async fn send_ping(
+        &self,
+        interface: Option<Interface>,
+        destination: IpAddr,
+    ) -> Result<(), Error> {
+        self.client
+            .send_ping(tarpc::context::current(), interface, destination)
+            .await?
+    }
+
+    /// Fetch the current location.
+    pub async fn geoip_lookup(&self) -> Result<AmIMullvad, Error> {
+        self.client.geoip_lookup(tarpc::context::current()).await?
+    }
+
+    /// Returns the IP of the given interface.
+    pub async fn get_interface_ip(&self, interface: Interface) -> Result<IpAddr, Error> {
+        self.client
+            .get_interface_ip(tarpc::context::current(), interface)
+            .await?
+    }
+
+    pub async fn resolve_hostname(&self, hostname: String) -> Result<Vec<SocketAddr>, Error> {
+        self.client
+            .resolve_hostname(tarpc::context::current(), hostname)
+            .await?
+    }
+}


### PR DESCRIPTION
Partially so that the context does not have to be passed to the underlying client for each RPC. It is also required for implementing a reboot RPC.