### PR TITLE
Add autoconnect tests

### DIFF
--- a/test-manager/src/tests/mod.rs
+++ b/test-manager/src/tests/mod.rs
@@ -75,6 +75,10 @@ pub async fn cleanup_after_test(
             log::debug!("Cleaning up daemon in test cleanup");
             if let Some(default_settings) = default_settings {
                 mullvad_client
+                    .set_auto_connect(default_settings.auto_connect)
+                    .await
+                    .expect("Could not set auto connect in cleanup");
+                mullvad_client
                     .set_allow_lan(default_settings.allow_lan)
                     .await
                     .expect("Could not set allow lan in cleanup");

--- a/test-manager/src/tests/tunnel.rs
+++ b/test-manager/src/tests/tunnel.rs
@@ -399,3 +399,45 @@ pub async fn test_wireguard_autoconnect(
 
     Ok(())
 }
+
+/// Test whether the daemon automatically connects on reboot when using
+/// OpenVPN.
+///
+/// # Limitations
+///
+/// This test does not guarantee that nothing leaks during boot or shutdown.
+#[test_function]
+pub async fn test_openvpn_autoconnect(
+    mut rpc: ServiceClient,
+    mut mullvad_client: ManagementServiceClient,
+) -> Result<(), Error> {
+    log::info!("Setting tunnel protocol to OpenVPN");
+
+    let relay_settings = RelaySettingsUpdate::Normal(RelayConstraintsUpdate {
+        location: Some(Constraint::Only(LocationConstraint::Country(
+            "se".to_string(),
+        ))),
+        tunnel_protocol: Some(Constraint::Only(TunnelType::OpenVpn)),
+        ..Default::default()
+    });
+
+    update_relay_settings(&mut mullvad_client, relay_settings)
+        .await
+        .expect("failed to update relay settings");
+
+    mullvad_client
+        .set_auto_connect(true)
+        .await
+        .expect("failed to enable auto-connect");
+
+    rpc.reboot().await?;
+
+    log::info!("Waiting for daemon to connect");
+
+    super::helpers::wait_for_tunnel_state(mullvad_client, |state| {
+        matches!(state, mullvad_types::states::TunnelState::Connected { .. })
+    })
+    .await?;
+
+    Ok(())
+}

--- a/test-manager/src/tests/tunnel.rs
+++ b/test-manager/src/tests/tunnel.rs
@@ -357,3 +357,45 @@ pub async fn test_multihop(
 
     Ok(())
 }
+
+/// Test whether the daemon automatically connects on reboot when using
+/// WireGuard.
+///
+/// # Limitations
+///
+/// This test does not guarantee that nothing leaks during boot or shutdown.
+#[test_function]
+pub async fn test_wireguard_autoconnect(
+    mut rpc: ServiceClient,
+    mut mullvad_client: ManagementServiceClient,
+) -> Result<(), Error> {
+    log::info!("Setting tunnel protocol to WireGuard");
+
+    let relay_settings = RelaySettingsUpdate::Normal(RelayConstraintsUpdate {
+        location: Some(Constraint::Only(LocationConstraint::Country(
+            "se".to_string(),
+        ))),
+        tunnel_protocol: Some(Constraint::Only(TunnelType::Wireguard)),
+        ..Default::default()
+    });
+
+    update_relay_settings(&mut mullvad_client, relay_settings)
+        .await
+        .expect("failed to update relay settings");
+
+    mullvad_client
+        .set_auto_connect(true)
+        .await
+        .expect("failed to enable auto-connect");
+
+    rpc.reboot().await?;
+
+    log::info!("Waiting for daemon to connect");
+
+    super::helpers::wait_for_tunnel_state(mullvad_client, |state| {
+        matches!(state, mullvad_types::states::TunnelState::Connected { .. })
+    })
+    .await?;
+
+    Ok(())
+}


### PR DESCRIPTION
Sanity checks the auto-connect setting. As is documented in the test, it is limited in that it does not test for leaks during shutdown or reboot.