### PR TITLE
Handle inconsistent desktop app versions

### DIFF
--- a/ci-runtests.sh
+++ b/ci-runtests.sh
@@ -195,8 +195,8 @@ echo "**********************************"
 echo "* Building test runners"
 echo "**********************************"
 
-# Clean up packages. Leaving stable versions as they rarely change.
-rm -f ${SCRIPT_DIR}/packages/*-dev-*
+# Clean up packages. Try to keep ones that match the versions we're testing
+find "${SCRIPT_DIR}/packages/" -type f ! \( -name "*${OLD_APP_VERSION}_*" -o -name "*${OLD_APP_VERSION}.*" -o -name "*${NEW_APP_VERSION}*" \) -delete
 
 function build_test_runners {
     for os in "${OSES[@]}"; do

--- a/scripts/build-runner-image.sh
+++ b/scripts/build-runner-image.sh
@@ -9,7 +9,7 @@
 
 set -eu
 
-TEST_RUNNER_IMAGE_SIZE_MB=500
+TEST_RUNNER_IMAGE_SIZE_MB=1000
 
 case $TARGET in
     "x86_64-unknown-linux-gnu")


### PR DESCRIPTION
We cannot rely on the API  endpoint anymore since the last stable version differs between platforms. As a workaround for now, use the GitHub API to obtain the last release.