### PR TITLE
Wait for Mullvad service after reboot

### DIFF
--- a/test-manager/src/tests/helpers.rs
+++ b/test-manager/src/tests/helpers.rs
@@ -21,7 +21,9 @@ use talpid_types::net::{
     wireguard::{PeerConfig, PrivateKey, TunnelConfig},
     IpVersion, TunnelType,
 };
-use test_rpc::{meta, package::Package, AmIMullvad, Interface, ServiceClient};
+use test_rpc::{
+    meta, mullvad_daemon::ServiceStatus, package::Package, AmIMullvad, Interface, ServiceClient,
+};
 use tokio::time::timeout;
 
 #[macro_export]
@@ -288,6 +290,34 @@ async fn wait_for_tunnel_state_inner(
                 )))
             }
         }
+    }
+}
+
+/// Wait for the Mullvad system service to enter a specified state
+pub async fn wait_for_mullvad_service_state(
+    rpc: &ServiceClient,
+    accept_state_fn: impl Fn(ServiceStatus) -> bool,
+) -> Result<(), Error> {
+    const MAX_ATTEMPTS: usize = 10;
+    const POLL_INTERVAL: Duration = Duration::from_secs(3);
+
+    let mut attempt = 0;
+
+    loop {
+        let last_state = rpc.mullvad_daemon_get_status().await?;
+        if accept_state_fn(last_state) {
+            break Ok(());
+        }
+
+        attempt += 1;
+        if attempt >= MAX_ATTEMPTS {
+            break Err(match last_state {
+                ServiceStatus::NotRunning => Error::DaemonNotRunning,
+                ServiceStatus::Running => Error::DaemonRunning,
+            });
+        }
+
+        tokio::time::sleep(POLL_INTERVAL).await;
     }
 }
 

--- a/test-rpc/src/mullvad_daemon.rs
+++ b/test-rpc/src/mullvad_daemon.rs
@@ -14,7 +14,7 @@ pub enum Error {
 
 pub type Result<T> = std::result::Result<T, Error>;
 
-#[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone, Copy)]
 pub enum ServiceStatus {
     NotRunning,
     Running,


### PR DESCRIPTION
This fixes the flakiness seen in the auto-connect tests.