### PR TITLE
Add DNS configuration and leak tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2499,6 +2499,7 @@ dependencies = [
 name = "test-manager"
 version = "0.1.0"
 dependencies = [
+ "base64",
  "bytes",
  "colored",
  "env_logger",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2507,6 +2507,7 @@ dependencies = [
  "futures",
  "inventory",
  "ipnetwork",
+ "itertools",
  "log",
  "mullvad-api",
  "mullvad-management-interface 0.0.0 (git+https://github.com/mullvad/mullvadvpn-app?branch=main)",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -485,6 +485,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "data-encoding"
+version = "2.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23d8666cb01533c39dde32bcbab8e227b4ed6679b2c925eba05feabea39508fb"
+
+[[package]]
+name = "data-encoding-macro"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86927b7cd2fe88fa698b87404b287ab98d1a0063a34071d92e575b72d3029aca"
+dependencies = [
+ "data-encoding",
+ "data-encoding-macro-internal",
+]
+
+[[package]]
+name = "data-encoding-macro-internal"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5bbed42daaa95e780b60a50546aa345b8413a1e46f9a40a12907d3598f038db"
+dependencies = [
+ "data-encoding",
+ "syn",
+]
+
+[[package]]
 name = "dbus"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2499,9 +2525,9 @@ dependencies = [
 name = "test-manager"
 version = "0.1.0"
 dependencies = [
- "base64",
  "bytes",
  "colored",
+ "data-encoding-macro",
  "env_logger",
  "err-derive",
  "futures",

--- a/README.md
+++ b/README.md
@@ -29,7 +29,8 @@ For macOS, the host machine must be macOS. All other platforms assume that the h
     dnf install git gcc protobuf-devel libpcap-devel qemu \
         podman e2tools mingw64-gcc mingw64-winpthreads-static mtools \
         golang-github-rootless-containers-rootlesskit slirp4netns dnsmasq \
-        dbus-devel pkgconf-pkg-config swtpm edk2-ovmf
+        dbus-devel pkgconf-pkg-config swtpm edk2-ovmf \
+        wireguard-tools
 
     rustup target add x86_64-pc-windows-gnu
     ```

--- a/scripts/destroy-network.sh
+++ b/scripts/destroy-network.sh
@@ -4,6 +4,7 @@ set -u
 
 exec 2> /dev/null
 
+ip link del dev wg-relay0
 ip link del lan-mullvadtest
 ip link del net-mullvadtest
 ip link del br-mullvadtest

--- a/scripts/setup-network.sh
+++ b/scripts/setup-network.sh
@@ -26,7 +26,7 @@ EOF
 
 # set up pingable hosts
 ip link add lan-mullvadtest type dummy
-ip addr add dev lan-mullvadtest 172.29.1.191
+ip addr add dev lan-mullvadtest 172.29.1.200
 ip link add net-mullvadtest type dummy
 ip addr add dev net-mullvadtest 1.3.3.7
 
@@ -39,7 +39,7 @@ ip addr add dev net-mullvadtest 1.3.3.7
 #
 # The public key of the peer is 7svBwGBefP7KVmH/yes+pZCfO6uSOYeGieYYa1+kZ0E=.
 #
-# The endpoint is 172.29.1.191:51820
+# The endpoint is 172.29.1.200:51820
 
 temp_wg_conf=$(mktemp)
 
@@ -61,7 +61,6 @@ ip link add dev wg-relay0 type wireguard
 ip addr add dev wg-relay0 192.168.15.1 peer 192.168.15.2
 wg setconf wg-relay0 ${temp_wg_conf}
 ip link set up dev wg-relay0
-ip route add dev wg-relay0 172.29.1.191/32
 
 # start DHCP server
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"

--- a/scripts/setup-network.sh
+++ b/scripts/setup-network.sh
@@ -26,9 +26,42 @@ EOF
 
 # set up pingable hosts
 ip link add lan-mullvadtest type dummy
-ip addr add dev lan-mullvadtest 172.29.1.200
+ip addr add dev lan-mullvadtest 172.29.1.191
 ip link add net-mullvadtest type dummy
 ip addr add dev net-mullvadtest 1.3.3.7
+
+# create wireguard relay
+
+# NOTE: This relay does not support PQ handshakes, etc.
+#
+# The client should connect to 192.168.15.1 using this private key:
+# mPue6Xt0pdz4NRAhfQSp/SLKo7kV7DW+2zvBq0N9iUI=
+#
+# The public key of the peer is 7svBwGBefP7KVmH/yes+pZCfO6uSOYeGieYYa1+kZ0E=.
+#
+# The endpoint is 172.29.1.191:51820
+
+temp_wg_conf=$(mktemp)
+
+trap "rm $temp_wg_conf" EXIT TERM
+
+cat <<CONF > $temp_wg_conf
+
+[Interface]
+PrivateKey = gLvQuyqazziyf+pUCAFUgTnWIwn6fPE5MOReOqPEGHU=
+ListenPort = 51820
+
+[Peer]
+PublicKey = h6elqt3dfamtS/p9jxJ8bIYs8UW9YHfTFhvx0fabTFo=
+AllowedIPs = 192.168.15.2
+
+CONF
+
+ip link add dev wg-relay0 type wireguard
+ip addr add dev wg-relay0 192.168.15.1 peer 192.168.15.2
+wg setconf wg-relay0 ${temp_wg_conf}
+ip link set up dev wg-relay0
+ip route add dev wg-relay0 172.29.1.191/32
 
 # start DHCP server
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"

--- a/test-manager/Cargo.toml
+++ b/test-manager/Cargo.toml
@@ -15,6 +15,7 @@ ipnetwork = "0.16"
 once_cell = "1.16.0"
 inventory = "0.1"
 base64 = "*"
+itertools = "0.10.5"
 
 serde = "1.0"
 tokio-serde = { version = "0.8.0", features = ["json"] }

--- a/test-manager/Cargo.toml
+++ b/test-manager/Cargo.toml
@@ -14,7 +14,7 @@ test_macro = { path = "./test_macro" }
 ipnetwork = "0.16"
 once_cell = "1.16.0"
 inventory = "0.1"
-base64 = "*"
+data-encoding-macro = "0.1.12"
 itertools = "0.10.5"
 
 serde = "1.0"

--- a/test-manager/Cargo.toml
+++ b/test-manager/Cargo.toml
@@ -14,6 +14,7 @@ test_macro = { path = "./test_macro" }
 ipnetwork = "0.16"
 once_cell = "1.16.0"
 inventory = "0.1"
+base64 = "*"
 
 serde = "1.0"
 tokio-serde = { version = "0.8.0", features = ["json"] }

--- a/test-manager/src/config.rs
+++ b/test-manager/src/config.rs
@@ -17,3 +17,5 @@ pub static CURRENT_APP_FILENAME: Lazy<String> = Lazy::new(|| {
 pub static UI_E2E_TESTS_FILENAME: Lazy<String> = Lazy::new(|| {
     std::env::var("UI_E2E_TESTS_FILENAME").expect("UI_E2E_TESTS_FILENAME is unspecified")
 });
+
+pub static LOCAL_WG_TUNNEL: &str = "wg-relay0";

--- a/test-manager/src/network_monitor.rs
+++ b/test-manager/src/network_monitor.rs
@@ -184,14 +184,6 @@ pub fn start_packet_monitor(
     start_packet_monitor_until(filter_fn, |_| true, monitor_options)
 }
 
-pub fn start_tunnel_packet_monitor(
-    filter_fn: impl Fn(&ParsedPacket) -> bool + Send + 'static,
-    mut monitor_options: MonitorOptions,
-) -> PacketMonitor {
-    monitor_options.no_frame = true;
-    start_tunnel_packet_monitor_until(filter_fn, |_| true, monitor_options)
-}
-
 pub fn start_packet_monitor_until(
     filter_fn: impl Fn(&ParsedPacket) -> bool + Send + 'static,
     should_continue_fn: impl FnMut(&ParsedPacket) -> bool + Send + 'static,

--- a/test-manager/src/network_monitor.rs
+++ b/test-manager/src/network_monitor.rs
@@ -12,14 +12,11 @@ use futures::{
 pub use pcap::Direction;
 use pcap::PacketCodec;
 use pnet_packet::{
-    ethernet::EtherTypes,
-    ip::{IpNextHeaderProtocol, IpNextHeaderProtocols},
-    ipv4::Ipv4Packet,
-    ipv6::Ipv6Packet,
-    tcp::TcpPacket,
-    udp::UdpPacket,
-    Packet,
+    ethernet::EtherTypes, ip::IpNextHeaderProtocol, ipv4::Ipv4Packet, ipv6::Ipv6Packet,
+    tcp::TcpPacket, udp::UdpPacket, Packet,
 };
+
+pub use pnet_packet::ip::IpNextHeaderProtocols as IpHeaderProtocols;
 
 struct Codec {
     no_frame: bool,
@@ -78,7 +75,7 @@ impl Codec {
         let protocol = packet.get_next_level_protocol();
 
         match protocol {
-            IpNextHeaderProtocols::Tcp => {
+            IpHeaderProtocols::Tcp => {
                 let seg = TcpPacket::new(packet.payload()).or_else(|| {
                     log::error!("invalid TCP segment");
                     None
@@ -86,7 +83,7 @@ impl Codec {
                 source.set_port(seg.get_source());
                 destination.set_port(seg.get_destination());
             }
-            IpNextHeaderProtocols::Udp => {
+            IpHeaderProtocols::Udp => {
                 let seg = UdpPacket::new(packet.payload()).or_else(|| {
                     log::error!("invalid UDP fragment");
                     None
@@ -94,7 +91,7 @@ impl Codec {
                 source.set_port(seg.get_source());
                 destination.set_port(seg.get_destination());
             }
-            IpNextHeaderProtocols::Icmp => {}
+            IpHeaderProtocols::Icmp => {}
             proto => log::debug!("ignoring v4 packet, transport/protocol type {proto}"),
         }
 
@@ -116,7 +113,7 @@ impl Codec {
 
         let protocol = packet.get_next_header();
         match protocol {
-            IpNextHeaderProtocols::Tcp => {
+            IpHeaderProtocols::Tcp => {
                 let seg = TcpPacket::new(packet.payload()).or_else(|| {
                     log::error!("invalid TCP segment");
                     None
@@ -124,7 +121,7 @@ impl Codec {
                 source.set_port(seg.get_source());
                 destination.set_port(seg.get_destination());
             }
-            IpNextHeaderProtocols::Udp => {
+            IpHeaderProtocols::Udp => {
                 let seg = UdpPacket::new(packet.payload()).or_else(|| {
                     log::error!("invalid UDP fragment");
                     None
@@ -132,7 +129,7 @@ impl Codec {
                 source.set_port(seg.get_source());
                 destination.set_port(seg.get_destination());
             }
-            IpNextHeaderProtocols::Icmpv6 => {}
+            IpHeaderProtocols::Icmpv6 => {}
             proto => log::debug!("ignoring v6 packet, transport/protocol type {proto}"),
         }
 

--- a/test-manager/src/tests/dns.rs
+++ b/test-manager/src/tests/dns.rs
@@ -1,0 +1,176 @@
+use std::net::SocketAddr;
+
+use mullvad_management_interface::ManagementServiceClient;
+use mullvad_types::{
+    relay_constraints::RelaySettingsUpdate, ConnectionConfig, CustomTunnelEndpoint,
+};
+use talpid_types::net::wireguard;
+use test_macro::test_function;
+use test_rpc::{Interface, ServiceClient};
+
+use super::{Error, helpers::connect_and_wait};
+use crate::network_monitor::{start_packet_monitor, start_tunnel_packet_monitor, MonitorOptions, Direction};
+
+use super::helpers::update_relay_settings;
+
+/// Test whether DNS leaks can be produced when using the default resolver. It does this by
+/// connecting to a custom WireGuard relay on localhost and monitoring outbound DNS traffic in (and
+/// outside of) the tunnel interface.
+///
+/// The test succeeds if and only if all expected outbound packets on port 53 are observed.
+///
+/// # Limitations
+///
+/// This test only detects outbound DNS leaks in the connected state.
+#[test_function]
+pub async fn test_dns_leak_default(
+    rpc: ServiceClient,
+    mullvad_client: ManagementServiceClient,
+) -> Result<(), Error> {
+    //
+    // Connect to local wireguard relay
+    //
+
+    connect_local_wg_relay(mullvad_client.clone())
+        .await
+        .expect("failed to connect to custom wg relay");
+
+    let guest_ip = rpc
+        .get_interface_ip(Interface::NonTunnel)
+        .await
+        .expect("failed to obtain guest IP");
+    let tunnel_ip = rpc
+        .get_interface_ip(Interface::Tunnel)
+        .await
+        .expect("failed to obtain tunnel IP");
+
+    log::debug!("Tunnel (guest) IP: {tunnel_ip}");
+    log::debug!("Non-tunnel (guest) IP: {guest_ip}");
+
+    //
+    // Spoof DNS packets
+    //
+
+    let tun_bind_addr = SocketAddr::new(tunnel_ip, 0);
+    let guest_bind_addr = SocketAddr::new(guest_ip, 0);
+
+    let whitelisted_dest = "192.168.15.1:53".parse().unwrap();
+    let blocked_dest_local = "10.64.100.100:53".parse().unwrap();
+    let blocked_dest_public = "1.3.3.7:53".parse().unwrap();
+
+    // Capture all outgoing DNS
+    let tunnel_monitor = start_tunnel_packet_monitor(
+        move |packet| packet.destination.port() == 53,
+        MonitorOptions {
+            direction: Some(Direction::In),
+            ..Default::default()
+        },
+    );
+    let non_tunnel_monitor = start_packet_monitor(
+        move |packet| packet.destination.port() == 53,
+        MonitorOptions {
+            direction: Some(Direction::In),
+            ..Default::default()
+        },
+    );
+    // Using the default resolver, we should observe 2 outgoing packets to the
+    // whitelisted destination on port 53, and only inside the tunnel.
+
+    spoof_packets(&rpc, tun_bind_addr, whitelisted_dest);
+    spoof_packets(&rpc, guest_bind_addr, whitelisted_dest);
+
+    spoof_packets(&rpc, tun_bind_addr, blocked_dest_local);
+    spoof_packets(&rpc, guest_bind_addr, blocked_dest_local);
+
+    spoof_packets(&rpc, tun_bind_addr, blocked_dest_public);
+    spoof_packets(&rpc, guest_bind_addr, blocked_dest_public);
+
+    tokio::time::sleep(std::time::Duration::from_secs(5)).await;
+
+    //
+    // Examine tunnel traffic
+    //
+
+    let tunnel_result = tunnel_monitor.into_result().await.unwrap();
+    assert!(
+        tunnel_result.packets.len() >= 2,
+        "expected at least in-tunnel 2 packets to allowed destination only"
+    );
+
+    for pkt in tunnel_result.packets {
+        assert_eq!(
+            pkt.destination, whitelisted_dest,
+            "unexpected tunnel packet on port 53"
+        );
+    }
+
+    //
+    // Examine non-tunnel traffic
+    //
+
+    let non_tunnel_result = non_tunnel_monitor.into_result().await.unwrap();
+    assert_eq!(
+        non_tunnel_result.packets.len(),
+        0,
+        "expected no non-tunnel packets on port 53"
+    );
+
+    Ok(())
+}
+
+/// Connect to the WireGuard relay that is set up in scripts/setup-network.sh
+/// See that script for details.
+async fn connect_local_wg_relay(mut mullvad_client: ManagementServiceClient) -> Result<(), Error> {
+    let peer_addr: SocketAddr = "172.29.1.200:51820".parse().unwrap();
+
+    let tun_self_addr: Ipv4Addr = Ipv4Addr::new(192, 168, 15, 2);
+    let tun_peer_addr: Ipv4Addr = Ipv4Addr::new(192, 168, 15, 1);
+
+    let public_key =
+        wireguard::PublicKey::from_base64("7svBwGBefP7KVmH/yes+pZCfO6uSOYeGieYYa1+kZ0E=").unwrap();
+    let private_key = wireguard::PrivateKey::from(
+        TryInto::<[u8; 32]>::try_into(
+            base64::decode("mPue6Xt0pdz4NRAhfQSp/SLKo7kV7DW+2zvBq0N9iUI=").unwrap(),
+        )
+        .unwrap(),
+    );
+
+    let relay_settings = RelaySettingsUpdate::CustomTunnelEndpoint(CustomTunnelEndpoint {
+        host: peer_addr.ip().to_string(),
+        config: ConnectionConfig::Wireguard(wireguard::ConnectionConfig {
+            tunnel: wireguard::TunnelConfig {
+                addresses: vec![IpAddr::V4(tun_self_addr)],
+                private_key,
+            },
+            peer: wireguard::PeerConfig {
+                public_key,
+                allowed_ips: vec!["0.0.0.0/0".parse().unwrap()],
+                endpoint: peer_addr,
+                psk: None,
+            },
+            ipv4_gateway: tun_peer_addr,
+            exit_peer: None,
+            fwmark: None,
+            ipv6_gateway: None,
+        }),
+    });
+
+    update_relay_settings(&mut mullvad_client, relay_settings)
+        .await
+        .expect("failed to update relay settings");
+
+    connect_and_wait(&mut mullvad_client).await?;
+
+    Ok(())
+}
+
+fn spoof_packets(rpc: &ServiceClient, bind_addr: SocketAddr, dest: SocketAddr) {
+    let rpc1 = rpc.clone();
+    let rpc2 = rpc.clone();
+    tokio::spawn(async move {
+        let _ = rpc1.send_tcp(bind_addr, dest).await;
+    });
+    tokio::spawn(async move {
+        let _ = rpc2.send_udp(bind_addr, dest).await;
+    });
+}

--- a/test-manager/src/tests/dns.rs
+++ b/test-manager/src/tests/dns.rs
@@ -1,6 +1,6 @@
-use std::net::SocketAddr;
+use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 
-use mullvad_management_interface::ManagementServiceClient;
+use mullvad_management_interface::{types, ManagementServiceClient};
 use mullvad_types::{
     relay_constraints::RelaySettingsUpdate, ConnectionConfig, CustomTunnelEndpoint,
 };
@@ -8,8 +8,10 @@ use talpid_types::net::wireguard;
 use test_macro::test_function;
 use test_rpc::{Interface, ServiceClient};
 
-use super::{Error, helpers::connect_and_wait};
-use crate::network_monitor::{start_packet_monitor, start_tunnel_packet_monitor, MonitorOptions, Direction};
+use super::{helpers::connect_and_wait, Error};
+use crate::network_monitor::{
+    start_packet_monitor, start_tunnel_packet_monitor, Direction, MonitorOptions,
+};
 
 use super::helpers::update_relay_settings;
 
@@ -168,9 +170,11 @@ fn spoof_packets(rpc: &ServiceClient, bind_addr: SocketAddr, dest: SocketAddr) {
     let rpc1 = rpc.clone();
     let rpc2 = rpc.clone();
     tokio::spawn(async move {
+        log::debug!("sending to {}/tcp from {}", dest, bind_addr);
         let _ = rpc1.send_tcp(bind_addr, dest).await;
     });
     tokio::spawn(async move {
+        log::debug!("sending to {}/udp from {}", dest, bind_addr);
         let _ = rpc2.send_udp(bind_addr, dest).await;
     });
 }

--- a/test-manager/src/tests/helpers.rs
+++ b/test-manager/src/tests/helpers.rs
@@ -144,10 +144,10 @@ pub async fn send_guest_probes(
         let tcp_rpc = rpc.clone();
         let udp_rpc = rpc.clone();
         tokio::spawn(async move {
-            let _ = tcp_rpc.send_tcp(bind_addr, destination).await;
+            let _ = tcp_rpc.send_tcp(interface, bind_addr, destination).await;
         });
         tokio::spawn(async move {
-            let _ = udp_rpc.send_udp(bind_addr, destination).await;
+            let _ = udp_rpc.send_udp(interface, bind_addr, destination).await;
         });
         ping_with_timeout(&rpc, destination.ip(), interface).await?;
         Ok::<(), Error>(())

--- a/test-manager/src/tests/helpers.rs
+++ b/test-manager/src/tests/helpers.rs
@@ -127,7 +127,8 @@ pub async fn send_guest_probes(
             timeout: Some(Duration::from_secs(3)),
             ..Default::default()
         },
-    );
+    )
+    .await;
 
     let bind_addr = if let Some(interface) = interface {
         SocketAddr::new(

--- a/test-manager/src/tests/install.rs
+++ b/test-manager/src/tests/install.rs
@@ -142,8 +142,8 @@ pub async fn test_upgrade_app(
     let ping_rpc = rpc.clone();
     let abort_on_drop = AbortOnDrop(tokio::spawn(async move {
         loop {
-            let _ = ping_rpc.send_tcp(bind_addr, inet_destination).await;
-            let _ = ping_rpc.send_udp(bind_addr, inet_destination).await;
+            let _ = ping_rpc.send_tcp(None, bind_addr, inet_destination).await;
+            let _ = ping_rpc.send_udp(None, bind_addr, inet_destination).await;
             let _ = ping_with_timeout(&ping_rpc, inet_destination.ip(), None).await;
             tokio::time::sleep(Duration::from_secs(1)).await;
         }

--- a/test-manager/src/tests/install.rs
+++ b/test-manager/src/tests/install.rs
@@ -137,7 +137,8 @@ pub async fn test_upgrade_app(
             packet.source.ip() == guest_ip && !api_endpoints.contains(&packet.destination.ip())
         },
         MonitorOptions::default(),
-    );
+    )
+    .await;
 
     let ping_rpc = rpc.clone();
     let abort_on_drop = AbortOnDrop(tokio::spawn(async move {

--- a/test-manager/src/tests/mod.rs
+++ b/test-manager/src/tests/mod.rs
@@ -110,6 +110,19 @@ pub async fn cleanup_after_test(
                     .clear_split_tunnel_processes(())
                     .await
                     .expect("Could not clear split tunnel processes in cleanup");
+                mullvad_client
+                    .set_dns_options(
+                        default_settings
+                            .tunnel_options
+                            .as_ref()
+                            .unwrap()
+                            .dns_options
+                            .as_ref()
+                            .unwrap()
+                            .clone(),
+                    )
+                    .await
+                    .expect("Could not clear dns options in cleanup");
             }
 
             reset_relay_settings(&mut mullvad_client).await?;

--- a/test-manager/src/tests/mod.rs
+++ b/test-manager/src/tests/mod.rs
@@ -1,4 +1,5 @@
 mod account;
+mod dns;
 mod helpers;
 mod install;
 mod settings;

--- a/test-manager/src/tests/tunnel.rs
+++ b/test-manager/src/tests/tunnel.rs
@@ -1,3 +1,5 @@
+use std::net::{IpAddr, Ipv4Addr};
+
 use super::helpers::{
     self, connect_and_wait, disconnect_and_wait, geoip_lookup_with_retries, ping_with_timeout,
     update_relay_settings,
@@ -12,7 +14,6 @@ use mullvad_types::relay_constraints::{
     RelaySettingsUpdate, WireguardConstraints,
 };
 use pnet_packet::ip::IpNextHeaderProtocols;
-use std::net::{IpAddr, Ipv4Addr};
 use talpid_types::net::{TransportProtocol, TunnelType};
 use test_macro::test_function;
 use test_rpc::mullvad_daemon::ServiceStatus;

--- a/test-manager/src/tests/tunnel.rs
+++ b/test-manager/src/tests/tunnel.rs
@@ -168,7 +168,8 @@ pub async fn test_udp2tcp_tunnel(
             packet.source.ip() != guest_ip || (packet.protocol == IpNextHeaderProtocols::Tcp)
         },
         MonitorOptions::default(),
-    );
+    )
+    .await;
 
     //
     // Verify that we can ping stuff
@@ -253,7 +254,8 @@ pub async fn test_bridge(
     let monitor = start_packet_monitor(
         |packet| packet.destination.ip() == EXPECTED_ENTRY_IP,
         MonitorOptions::default(),
-    );
+    )
+    .await;
 
     connect_and_wait(&mut mullvad_client).await?;
 
@@ -333,7 +335,8 @@ pub async fn test_multihop(
                 && packet.protocol == IpNextHeaderProtocols::Udp
         },
         MonitorOptions::default(),
-    );
+    )
+    .await;
 
     connect_and_wait(&mut mullvad_client).await?;
 

--- a/test-rpc/src/client.rs
+++ b/test-rpc/src/client.rs
@@ -111,22 +111,24 @@ impl ServiceClient {
     /// Send TCP packet
     pub async fn send_tcp(
         &self,
+        interface: Option<Interface>,
         bind_addr: SocketAddr,
         destination: SocketAddr,
     ) -> Result<(), Error> {
         self.client
-            .send_tcp(tarpc::context::current(), bind_addr, destination)
+            .send_tcp(tarpc::context::current(), interface, bind_addr, destination)
             .await?
     }
 
     /// Send UDP packet
     pub async fn send_udp(
         &self,
+        interface: Option<Interface>,
         bind_addr: SocketAddr,
         destination: SocketAddr,
     ) -> Result<(), Error> {
         self.client
-            .send_udp(tarpc::context::current(), bind_addr, destination)
+            .send_udp(tarpc::context::current(), interface, bind_addr, destination)
             .await?
     }
 

--- a/test-rpc/src/lib.rs
+++ b/test-rpc/src/lib.rs
@@ -105,10 +105,18 @@ mod service {
         async fn find_mullvad_app_traces() -> Result<Vec<AppTrace>, Error>;
 
         /// Send TCP packet
-        async fn send_tcp(bind_addr: SocketAddr, destination: SocketAddr) -> Result<(), Error>;
+        async fn send_tcp(
+            interface: Option<Interface>,
+            bind_addr: SocketAddr,
+            destination: SocketAddr,
+        ) -> Result<(), Error>;
 
         /// Send UDP packet
-        async fn send_udp(bind_addr: SocketAddr, destination: SocketAddr) -> Result<(), Error>;
+        async fn send_udp(
+            interface: Option<Interface>,
+            bind_addr: SocketAddr,
+            destination: SocketAddr,
+        ) -> Result<(), Error>;
 
         /// Send ICMP
         async fn send_ping(interface: Option<Interface>, destination: IpAddr) -> Result<(), Error>;

--- a/test-runner/src/main.rs
+++ b/test-runner/src/main.rs
@@ -146,7 +146,7 @@ impl Service for TestServer {
         _: context::Context,
         hostname: String,
     ) -> Result<Vec<SocketAddr>, test_rpc::Error> {
-        Ok(tokio::net::lookup_host(hostname)
+        Ok(tokio::net::lookup_host(&format!("{hostname}:0"))
             .await
             .map_err(|error| {
                 log::debug!("resolve_hostname failed: {error}");

--- a/test-runner/src/main.rs
+++ b/test-runner/src/main.rs
@@ -108,19 +108,21 @@ impl Service for TestServer {
     async fn send_tcp(
         self,
         _: context::Context,
+        interface: Option<Interface>,
         bind_addr: SocketAddr,
         destination: SocketAddr,
     ) -> Result<(), test_rpc::Error> {
-        net::send_tcp(bind_addr, destination).await
+        net::send_tcp(interface, bind_addr, destination).await
     }
 
     async fn send_udp(
         self,
         _: context::Context,
+        interface: Option<Interface>,
         bind_addr: SocketAddr,
         destination: SocketAddr,
     ) -> Result<(), test_rpc::Error> {
-        net::send_udp(bind_addr, destination).await
+        net::send_udp(interface, bind_addr, destination).await
     }
 
     async fn send_ping(


### PR DESCRIPTION
These tests ensure that there are no DNS leaks, both inside and outside of the tunnel, for the default resolver and for custom DNS. They also make sure that outbound traffic *is* observed when expected.

In addition to leak tests, the PR also includes tests checking whether the system uses the correct resolver:

* `test_dns_config_default`
* `test_dns_config_custom_private`
* `test_dns_config_custom_public`
* `test_content_blockers`

Fixes DES-56.
Fixes DES-55.