### PR TITLE
Test system DNS configuration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2507,6 +2507,7 @@ dependencies = [
  "futures",
  "inventory",
  "ipnetwork",
+ "itertools",
  "log",
  "mullvad-api",
  "mullvad-management-interface 0.0.0 (git+https://github.com/mullvad/mullvadvpn-app?branch=main)",

--- a/test-manager/Cargo.toml
+++ b/test-manager/Cargo.toml
@@ -15,6 +15,7 @@ ipnetwork = "0.16"
 once_cell = "1.16.0"
 inventory = "0.1"
 base64 = "*"
+itertools = "0.10.5"
 
 serde = "1.0"
 tokio-serde = { version = "0.8.0", features = ["json"] }


### PR DESCRIPTION
This PR adds tests for testing whether the system uses the correct resolver:

* `test_dns_config_default`
* `test_dns_config_custom_private`
* `test_dns_config_custom_public`
* `test_content_blockers`

These are separate from the [leak tests](https://github.com/mullvad/mullvadvpn-app-tests/pull/55).