### PR TITLE
Add support for macOS runners

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,11 +21,23 @@ etc.
 
 For macOS, the host machine must be macOS. All other platforms assume that the host is Linux.
 
+## All platforms
+
 * Get the latest stable Rust from https://rustup.rs/.
+
+## macOS
+
+Normally, you would use Tart here. It can be installed with Homebrew:
+
+    ```bash
+    brew install cirruslabs/cli/tart
+    ```
+
+## Linux
 
 * For running tests on Linux and Windows guests, you will need these tools and libraries:
 
-    ```
+    ```bash
     dnf install git gcc protobuf-devel libpcap-devel qemu \
         podman e2tools mingw64-gcc mingw64-winpthreads-static mtools \
         golang-github-rootless-containers-rootlesskit slirp4netns dnsmasq \
@@ -43,10 +55,13 @@ See [`BUILD_OS_IMAGE.md`](./BUILD_OS_IMAGE.md) for how to build images for runni
 
 See `cargo run --bin test-manager` for details.
 
+## Linux
+
 Here is an example of how to create a new OS configuration and then run all tests:
 
 ```bash
 # Create or edit configuration
+# The image is assumed to contain a test runner service set up as described in ./BUILD_OS_IMAGE.md
 test-manager set debian11 qemu ./os-images/debian11.qcow2 linux \
     --package-type deb --architecture x64 \
     --artifacts-dir /opt/testing \
@@ -61,6 +76,23 @@ test-manager run-tests debian11 \
     --account 0123456789 \
     --current-app abc123 \
     --previous-app 2023.2
+```
+
+## macOS
+
+Here is an example of how to create a new OS (Apple Silicon) configuration:
+
+```bash
+# Download some VM image
+tart clone ghcr.io/cirruslabs/macos-ventura-base:latest ventura-base
+
+# Create or edit configuration
+test-manager set macos-ventura tart ventura-base macos --architecture aarch64
+
+# Try it out to see if it works
+#test-manager run macos-ventura
+
+# TODO: Run all tests
 ```
 
 ## Note on `ci-runtests.sh`

--- a/test-manager/src/config.rs
+++ b/test-manager/src/config.rs
@@ -127,6 +127,8 @@ pub struct VmConfig {
 pub enum VmType {
     /// QEMU VM
     Qemu,
+    /// Tart VM
+    Tart,
 }
 
 #[derive(clap::ValueEnum, Debug, Serialize, Deserialize, Clone, Copy, PartialEq, Eq)]

--- a/test-manager/src/container.rs
+++ b/test-manager/src/container.rs
@@ -1,3 +1,5 @@
+#![cfg(target_os = "linux")]
+
 use tokio::process::Command;
 
 /// Re-launch self with rootlesskit if we're not root.

--- a/test-manager/src/main.rs
+++ b/test-manager/src/main.rs
@@ -113,6 +113,7 @@ enum Commands {
 
 #[tokio::main]
 async fn main() -> Result<(), Error> {
+    #[cfg(target_os = "linux")]
     container::relaunch_with_rootlesskit().await;
 
     init_logger();

--- a/test-manager/src/package.rs
+++ b/test-manager/src/package.rs
@@ -109,8 +109,11 @@ async fn find_app(
 
         // Skip file if it doesn't match the architecture
         if let Some(arch) = package_type.2 {
-            if !arch.get_identifiers().iter().any(|id| u8_path.contains(id)) {
-                continue;
+            // Skip for non-e2e bin on non-Linux, because there's only one package
+            if e2e_bin || package_type.0 == OsType::Linux {
+                if !arch.get_identifiers().iter().any(|id| u8_path.contains(id)) {
+                    continue;
+                }
             }
         }
 

--- a/test-manager/src/tests/dns.rs
+++ b/test-manager/src/tests/dns.rs
@@ -623,6 +623,7 @@ async fn connect_local_wg_relay(mullvad_client: &mut ManagementServiceClient) ->
             },
             ipv4_gateway: CUSTOM_TUN_GATEWAY,
             exit_peer: None,
+            #[cfg(target_os = "linux")]
             fwmark: None,
             ipv6_gateway: None,
         }),

--- a/test-manager/src/vm/tart.rs
+++ b/test-manager/src/vm/tart.rs
@@ -1,0 +1,231 @@
+use crate::config::{Config, VmConfig};
+use regex::Regex;
+use std::{
+    io,
+    net::IpAddr,
+    ops::Deref,
+    process::{ExitStatus, Stdio},
+    sync::Arc,
+    time::Duration,
+};
+use tokio::process::{Child, Command};
+use uuid::Uuid;
+
+use super::{logging::forward_logs, util::find_pty, VmInstance};
+
+const LOG_PREFIX: &str = "[tart] ";
+const STDERR_LOG_LEVEL: log::Level = log::Level::Error;
+const STDOUT_LOG_LEVEL: log::Level = log::Level::Debug;
+const OBTAIN_IP_TIMEOUT: Duration = Duration::from_secs(60);
+
+#[derive(err_derive::Error, Debug)]
+#[error(no_from)]
+pub enum Error {
+    #[error(display = "Failed to run 'tart clone'")]
+    RunClone(#[error(source)] io::Error),
+    #[error(display = "'tart clone' failed: {}", _0)]
+    CloneFailed(ExitStatus),
+    #[error(display = "Failed to run 'tart delete'")]
+    RunDelete(#[error(source)] io::Error),
+    #[error(display = "'tart delete' failed: {}", _0)]
+    DeleteFailed(ExitStatus),
+    #[error(display = "Failed to start Tart")]
+    StartTart(#[error(source)] io::Error),
+    #[error(display = "Tart exited unexpectedly")]
+    TartFailed(Option<ExitStatus>),
+    #[error(display = "Failed to obtain IP of guest")]
+    ObtainIp(#[error(source)] io::Error),
+    #[error(display = "'tart ip' output: invalid utf-8")]
+    IpOutputInvalidUtf8,
+    #[error(display = "Failed to parse output of 'tart ip'")]
+    ParseIpOutput,
+    #[error(display = "Could not find pty")]
+    NoPty,
+}
+
+pub type Result<T> = std::result::Result<T, Error>;
+
+#[derive(Clone)]
+pub struct TartInstance(Arc<TartInstanceInner>);
+
+impl Deref for TartInstance {
+    type Target = TartInstanceInner;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+pub struct TartInstanceInner {
+    pub pty_path: String,
+    pub ip_addr: IpAddr,
+    child: Child,
+    machine_copy: Option<MachineCopy>,
+}
+
+#[async_trait::async_trait]
+impl VmInstance for TartInstance {
+    fn get_pty(&self) -> &str {
+        &self.pty_path
+    }
+
+    fn get_ip(&self) -> &IpAddr {
+        &self.ip_addr
+    }
+
+    async fn wait(&mut self) {
+        let inner = Arc::get_mut(&mut self.0).unwrap();
+        let _ = inner.child.wait().await;
+        if let Some(machine) = inner.machine_copy.take() {
+            machine.cleanup().await;
+        }
+    }
+}
+
+pub async fn run(config: &Config, vm_config: &VmConfig) -> Result<TartInstance> {
+    // Create a temporary clone of the machine
+    let machine_copy = if config.keep_changes {
+        MachineCopy::borrow_vm(&vm_config.image_path)
+    } else {
+        MachineCopy::clone_vm(&vm_config.image_path).await?
+    };
+
+    // Start VM
+    let mut tart_cmd = Command::new("tart");
+    tart_cmd.args(["run", &machine_copy.name, "--serial"]);
+
+    if !vm_config.disks.is_empty() {
+        log::warn!("Mounting disks is not yet supported")
+    }
+
+    if !config.display {
+        tart_cmd.arg("--no-graphics");
+    }
+
+    tart_cmd.stdin(Stdio::piped());
+    tart_cmd.stdout(Stdio::piped());
+    tart_cmd.stderr(Stdio::piped());
+
+    tart_cmd.kill_on_drop(true);
+
+    let mut child = tart_cmd.spawn().map_err(Error::StartTart)?;
+
+    tokio::spawn(forward_logs(
+        LOG_PREFIX,
+        child.stderr.take().unwrap(),
+        STDERR_LOG_LEVEL,
+    ));
+
+    // find pty in stdout
+    // match: Successfully open pty /dev/ttys001
+    let re = Regex::new(r"Successfully open pty ([/a-zA-Z0-9]+)$").unwrap();
+    let pty_path = find_pty(re, &mut child, STDOUT_LOG_LEVEL, LOG_PREFIX)
+        .await
+        .map_err(|_error| {
+            if let Ok(Some(status)) = child.try_wait() {
+                return Error::TartFailed(Some(status));
+            }
+            Error::NoPty
+        })?;
+
+    tokio::spawn(forward_logs(
+        LOG_PREFIX,
+        child.stdout.take().unwrap(),
+        STDOUT_LOG_LEVEL,
+    ));
+
+    // Get IP address of VM
+    log::debug!("Waiting for IP address");
+
+    let mut tart_cmd = Command::new("tart");
+    tart_cmd.args([
+        "ip",
+        &machine_copy.name,
+        "--wait",
+        &format!("{}", OBTAIN_IP_TIMEOUT.as_secs()),
+    ]);
+    let output = tart_cmd.output().await.map_err(Error::ObtainIp)?;
+    let ip_addr = std::str::from_utf8(&output.stdout)
+        .map_err(|_err| Error::IpOutputInvalidUtf8)?
+        .trim()
+        .parse()
+        .map_err(|_err| Error::ParseIpOutput)?;
+
+    log::debug!("Guest IP: {ip_addr}");
+
+    Ok(TartInstance(Arc::new(TartInstanceInner {
+        child,
+        pty_path,
+        ip_addr,
+        machine_copy: Some(machine_copy),
+    })))
+}
+
+/// Handle for a transient or borrowed Tart VM.
+/// TODO: Prune VMs we fail to delete them somehow.
+pub struct MachineCopy {
+    name: String,
+    should_destroy: bool,
+}
+
+impl MachineCopy {
+    /// Use an existing VM and save all changes to it.
+    pub fn borrow_vm(name: &str) -> Self {
+        Self {
+            name: name.to_owned(),
+            should_destroy: false,
+        }
+    }
+
+    /// Clone an existing VM and destroy changes when self is dropped.
+    pub async fn clone_vm(name: &str) -> Result<Self> {
+        let clone_name = format!("test-{}", Uuid::new_v4().to_string());
+
+        let mut tart_cmd = Command::new("tart");
+        tart_cmd.args(["clone", name, &clone_name]);
+        let output = tart_cmd.status().await.map_err(Error::RunClone)?;
+        if !output.success() {
+            return Err(Error::CloneFailed(output));
+        }
+
+        Ok(Self {
+            name: clone_name,
+            should_destroy: true,
+        })
+    }
+
+    pub async fn cleanup(mut self) {
+        let _ = tokio::task::spawn_blocking(move || self.try_destroy()).await;
+    }
+
+    fn try_destroy(&mut self) {
+        if !self.should_destroy {
+            return;
+        }
+
+        if let Err(error) = self.destroy_inner() {
+            log::error!("Failed to destroy Tart clone: {error}");
+        } else {
+            self.should_destroy = false;
+        }
+    }
+
+    fn destroy_inner(&mut self) -> Result<()> {
+        use std::process::Command;
+
+        let mut tart_cmd = Command::new("tart");
+        tart_cmd.args(["delete", &self.name]);
+        let output = tart_cmd.status().map_err(Error::RunDelete)?;
+        if !output.success() {
+            return Err(Error::DeleteFailed(output));
+        }
+
+        Ok(())
+    }
+}
+
+impl Drop for MachineCopy {
+    fn drop(&mut self) {
+        self.try_destroy();
+    }
+}

--- a/test-manager/src/vm/util.rs
+++ b/test-manager/src/vm/util.rs
@@ -1,0 +1,42 @@
+use std::time::Duration;
+
+use regex::Regex;
+use tokio::{
+    io::{AsyncBufReadExt, BufReader},
+    time::timeout,
+};
+
+const OBTAIN_PTY_TIMEOUT: Duration = Duration::from_secs(5);
+
+pub struct NoPty;
+
+/// Extract pty path from stdout
+pub async fn find_pty(
+    re: Regex,
+    process: &mut tokio::process::Child,
+    log_level: log::Level,
+    log_prefix: &str,
+) -> Result<String, NoPty> {
+    let stdout = process.stdout.take().unwrap();
+    let stdout_reader = BufReader::new(stdout);
+
+    let (pty_path, reader) = timeout(OBTAIN_PTY_TIMEOUT, async {
+        let mut lines = stdout_reader.lines();
+
+        while let Ok(Some(line)) = lines.next_line().await {
+            log::log!(log_level, "{log_prefix}{line}");
+
+            if let Some(path) = re.captures(&line).and_then(|cap| cap.get(1)) {
+                return Ok((path.as_str().to_owned(), lines.into_inner()));
+            }
+        }
+
+        Err(NoPty)
+    })
+    .await
+    .map_err(|_| NoPty)??;
+
+    process.stdout.replace(reader.into_inner());
+
+    Ok(pty_path)
+}

--- a/test-runner/src/net.rs
+++ b/test-runner/src/net.rs
@@ -32,7 +32,9 @@ pub async fn send_tcp(
     if let Some(iface) = bind_interface {
         let iface = get_interface_name(iface);
 
-        #[cfg(not(windows))]
+        // TODO: macos
+
+        #[cfg(target_os = "linux")]
         socket
             .bind_device(Some(iface.as_bytes()))
             .map_err(|error| {
@@ -77,7 +79,9 @@ pub async fn send_udp(
     if let Some(iface) = bind_interface {
         let iface = get_interface_name(iface);
 
-        #[cfg(not(windows))]
+        // TODO: macos
+
+        #[cfg(target_os = "linux")]
         socket
             .bind_device(Some(iface.as_bytes()))
             .map_err(|error| {


### PR DESCRIPTION
This PR does not include an SSH provisioner (needed to set up the test runner if it's not built into the image), nor does it implement all features for macOS in `test-runner`. See the readme for more info.