### PR TITLE
Add SSH provisioner

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1218,7 +1218,7 @@ dependencies = [
  "jni",
  "jnix-macros",
  "once_cell",
- "parking_lot",
+ "parking_lot 0.12.1",
 ]
 
 [[package]]
@@ -1271,6 +1271,32 @@ checksum = "351a32417a12d5f7e82c368a66781e307834dae04c6ce0cd4456d52989229883"
 dependencies = [
  "cfg-if",
  "winapi",
+]
+
+[[package]]
+name = "libssh2-sys"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dc8a030b787e2119a731f1951d6a773e2280c660f8ec4b0f5e1505a386e71ee"
+dependencies = [
+ "cc",
+ "libc",
+ "libz-sys",
+ "openssl-sys",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
+name = "libz-sys"
+version = "1.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9702761c3935f8cc2f101793272e202c72b99da8f4224a19ddcf1279a6450bbf"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
 ]
 
 [[package]]
@@ -1635,6 +1661,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
+name = "openssl-sys"
+version = "0.9.81"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "176be2629957c157240f68f61f2d0053ad3a4ecfdd9ebf1e6521d18d9635cf67"
+dependencies = [
+ "autocfg",
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
 name = "opentelemetry"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1697,12 +1736,37 @@ dependencies = [
 
 [[package]]
 name = "parking_lot"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d17b78036a60663b797adeaee46f5c9dfebb86948d1255007a1d6be0271ff99"
+dependencies = [
+ "instant",
+ "lock_api",
+ "parking_lot_core 0.8.6",
+]
+
+[[package]]
+name = "parking_lot"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
 dependencies = [
  "lock_api",
- "parking_lot_core",
+ "parking_lot_core 0.9.4",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60a2cfe6f0ad2bfc16aefa463b497d5c7a5ecd44a23efa72aa342d90177356dc"
+dependencies = [
+ "cfg-if",
+ "instant",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "winapi",
 ]
 
 [[package]]
@@ -2464,6 +2528,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
+name = "ssh2"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7fe461910559f6d5604c3731d00d2aafc4a83d1665922e280f42f9a168d5455"
+dependencies = [
+ "bitflags",
+ "libc",
+ "libssh2-sys",
+ "parking_lot 0.11.2",
+]
+
+[[package]]
 name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2683,6 +2759,7 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
+ "ssh2",
  "talpid-types 0.0.0 (git+https://github.com/mullvad/mullvadvpn-app?branch=main)",
  "tarpc",
  "test-rpc",
@@ -2826,7 +2903,7 @@ dependencies = [
  "memchr",
  "mio",
  "num_cpus",
- "parking_lot",
+ "parking_lot 0.12.1",
  "pin-project-lite",
  "signal-hook-registry",
  "socket2",
@@ -3202,6 +3279,12 @@ name = "valuable"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version_check"

--- a/README.md
+++ b/README.md
@@ -80,19 +80,28 @@ test-manager run-tests debian11 \
 
 ## macOS
 
-Here is an example of how to create a new OS (Apple Silicon) configuration:
+Here is an example of how to create a new OS configuration (on Apple Silicon) and then run all
+tests:
 
 ```bash
 # Download some VM image
 tart clone ghcr.io/cirruslabs/macos-ventura-base:latest ventura-base
 
 # Create or edit configuration
-test-manager set macos-ventura tart ventura-base macos --architecture aarch64
+# Use SSH to deploy the test runner since the image doesn't contain a runner
+test-manager set macos-ventura tart ventura-base macos \
+    --architecture aarch64 \
+    --provisioner ssh --ssh-user admin --ssh-password admin
 
 # Try it out to see if it works
 #test-manager run-vm macos-ventura
 
-# TODO: Run all tests
+# Run all tests
+test-manager run-tests macos-ventura \
+    --display \
+    --account 0123456789 \
+    --current-app <git hash or tag> \
+    --previous-app 2023.2
 ```
 
 ## Note on `ci-runtests.sh`

--- a/scripts/ssh-setup.sh
+++ b/scripts/ssh-setup.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+
+set -eu
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+cd $SCRIPT_DIR
+
+RUNNER_DIR="$1"
+CURRENT_APP="$2"
+PREVIOUS_APP="$3"
+UI_RUNNER="$4"
+
+# Copy over test runner to correct place
+
+echo "Copying test-runner to $RUNNER_DIR"
+
+mkdir -p $RUNNER_DIR
+
+for file in test-runner $CURRENT_APP $PREVIOUS_APP $UI_RUNNER; do
+    echo "Moving $file to $RUNNER_DIR"
+    cp -f "$SCRIPT_DIR/$file" $RUNNER_DIR
+done
+
+chown -R root "$RUNNER_DIR/"
+
+# Create service
+
+function setup_macos {
+    RUNNER_PLIST_PATH="/Library/LaunchDaemons/net.mullvad.testunner.plist"
+
+    echo "Creating test runner service as $RUNNER_PLIST_PATH"
+
+    cat > $RUNNER_PLIST_PATH << EOF
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>net.mullvad.testrunner</string>
+
+    <key>ProgramArguments</key>
+    <array>
+        <string>$RUNNER_DIR/test-runner</string>
+        <string>/dev/tty.virtio</string>
+        <string>serve</string>
+    </array>
+
+    <key>UserName</key>
+    <string>root</string>
+
+    <key>RunAtLoad</key>
+    <true/>
+
+    <key>KeepAlive</key>
+    <true/>
+
+    <key>StandardOutPath</key>
+    <string>/tmp/runner.out</string>
+
+    <key>StandardErrorPath</key>
+    <string>/tmp/runner.err</string>
+</dict>
+</plist>
+EOF
+
+    echo "Starting test runner service"
+
+    launchctl load -w $RUNNER_PLIST_PATH
+}
+
+function setup_systemd {
+    RUNNER_SERVICE_PATH="/etc/systemd/system/testrunner.service"
+
+    echo "Creating test runner service as $RUNNER_SERVICE_PATH"
+
+    cat > $RUNNER_SERVICE_PATH << EOF
+[Unit]
+Description=Mullvad Test Runner
+
+[Service]
+ExecStart=$RUNNER_DIR/test-runner /dev/ttyS0 serve
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+    echo "Starting test runner service"
+
+    semanage fcontext -a -t bin_t "$RUNNER_DIR/.*" &> /dev/null || true
+
+    systemctl enable testrunner.service
+    systemctl start testrunner.service
+}
+
+if [[ "$(uname -s)" == "Darwin" ]]; then
+    setup_macos
+    exit 0
+fi
+
+setup_systemd

--- a/test-manager/Cargo.toml
+++ b/test-manager/Cargo.toml
@@ -45,6 +45,8 @@ talpid-types = { git = "https://github.com/mullvad/mullvadvpn-app", branch = "ma
 mullvad-types = { git = "https://github.com/mullvad/mullvadvpn-app", branch = "main" }
 mullvad-api = { git = "https://github.com/mullvad/mullvadvpn-app", branch = "main" }
 
+ssh2 = "0.9.4"
+
 [dependencies.tokio-util]
 version = "0.7"
 features = ["codec"]

--- a/test-manager/build.rs
+++ b/test-manager/build.rs
@@ -1,0 +1,4 @@
+fn main() {
+    // Rebuild if SSH provision script changes
+    println!("cargo:rerun-if-changed=../scripts/ssh-setup.sh");
+}

--- a/test-manager/src/config.rs
+++ b/test-manager/src/config.rs
@@ -107,6 +107,14 @@ pub struct VmConfig {
     #[arg(long, default_value = "noop")]
     pub provisioner: Provisioner,
 
+    /// Username to use for SSH
+    #[arg(long, required_if_eq("provisioner", "ssh"))]
+    pub ssh_user: Option<String>,
+
+    /// Password to use for SSH
+    #[arg(long, required_if_eq("provisioner", "ssh"))]
+    pub ssh_password: Option<String>,
+
     /// Additional disk images to mount/include
     #[arg(long)]
     pub disks: Vec<String>,
@@ -120,6 +128,43 @@ pub struct VmConfig {
     #[serde(default)]
     #[arg(long)]
     pub tpm: bool,
+}
+
+impl VmConfig {
+    /// Combine authentication details, if all are present
+    pub fn get_ssh_options(&self) -> Option<(&str, &str)> {
+        Some((self.ssh_user.as_ref()?, self.ssh_password.as_ref()?))
+    }
+
+    pub fn get_runner_dir(&self) -> &Path {
+        match self.architecture {
+            None | Some(Architecture::X64) => self.get_x64_runner_dir(),
+            Some(Architecture::Aarch64) => self.get_aarch64_runner_dir(),
+        }
+    }
+
+    fn get_x64_runner_dir(&self) -> &Path {
+        pub const X64_LINUX_TARGET_DIR: &str = "target/x86_64-unknown-linux-gnu/release";
+        pub const X64_WINDOWS_TARGET_DIR: &str = "target/x86_64-pc-windows-gnu/release";
+        pub const X64_MACOS_TARGET_DIR: &str = "target/x86_64-apple-darwin/release";
+
+        match self.os_type {
+            OsType::Linux => Path::new(X64_LINUX_TARGET_DIR),
+            OsType::Windows => Path::new(X64_WINDOWS_TARGET_DIR),
+            OsType::Macos => Path::new(X64_MACOS_TARGET_DIR),
+        }
+    }
+
+    fn get_aarch64_runner_dir(&self) -> &Path {
+        pub const AARCH64_LINUX_TARGET_DIR: &str = "target/aarch64-unknown-linux-gnu/release";
+        pub const AARCH64_MACOS_TARGET_DIR: &str = "target/aarch64-apple-darwin/release";
+
+        match self.os_type {
+            OsType::Linux => Path::new(AARCH64_LINUX_TARGET_DIR),
+            OsType::Macos => Path::new(AARCH64_MACOS_TARGET_DIR),
+            _ => unimplemented!(),
+        }
+    }
 }
 
 #[derive(clap::ValueEnum, Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
@@ -168,4 +213,6 @@ pub enum Provisioner {
     /// Do nothing: The image already includes a test runner service
     #[default]
     Noop,
+    /// Set up test runner over SSH.
+    Ssh,
 }

--- a/test-manager/src/main.rs
+++ b/test-manager/src/main.rs
@@ -155,9 +155,11 @@ async fn main() -> Result<()> {
             let mut instance = vm::run(&config, &name)
                 .await
                 .context("Failed to start VM")?;
-            let artifacts_dir = vm::provision(&config, &name, &instance)
+            let artifacts_dir = vm::provision(&config, &name, &instance, &manifest)
                 .await
                 .context("Failed to run provisioning for VM")?;
+
+            let skip_wait = vm_config.provisioner != config::Provisioner::Noop;
 
             let result = run_tests::run(
                 tests::config::TestConfig {
@@ -184,6 +186,7 @@ async fn main() -> Result<()> {
                 },
                 &instance,
                 &test_filters,
+                skip_wait,
             )
             .await
             .context("Tests failed");

--- a/test-manager/src/package.rs
+++ b/test-manager/src/package.rs
@@ -8,6 +8,7 @@ use tokio::fs;
 const VERSION_REGEX: Lazy<Regex> =
     Lazy::new(|| Regex::new(r"\d{4}\.\d+(-beta\d+)?(-dev)?-([0-9a-z])+").unwrap());
 
+#[derive(Debug, Clone)]
 pub struct Manifest {
     pub current_app_path: PathBuf,
     pub previous_app_path: PathBuf,

--- a/test-manager/src/run_tests.rs
+++ b/test-manager/src/run_tests.rs
@@ -9,6 +9,7 @@ pub async fn run(
     config: tests::config::TestConfig,
     instance: &Box<dyn vm::VmInstance>,
     test_filters: &[String],
+    skip_wait: bool,
 ) -> Result<()> {
     log::trace!("Setting test constants");
     tests::config::TEST_CONFIG.init(config);
@@ -22,7 +23,9 @@ pub async fn run(
     let (runner_transport, mullvad_daemon_transport, mut connection_handle, completion_handle) =
         test_rpc::transport::create_client_transports(serial_stream).await?;
 
-    connection_handle.wait_for_server().await?;
+    if !skip_wait {
+        connection_handle.wait_for_server().await?;
+    }
 
     log::info!("Running client");
 

--- a/test-manager/src/vm/mod.rs
+++ b/test-manager/src/vm/mod.rs
@@ -1,4 +1,7 @@
-use crate::config::{Config, ConfigFile, VmConfig, VmType};
+use crate::{
+    config::{Config, ConfigFile, VmConfig, VmType},
+    package,
+};
 use anyhow::{Context, Result};
 use std::net::IpAddr;
 
@@ -57,13 +60,10 @@ pub async fn provision(
     config: &Config,
     name: &str,
     instance: &Box<dyn VmInstance>,
+    app_manifest: &package::Manifest,
 ) -> Result<String> {
-    log::info!("Provisioning");
-
     let vm_conf = get_vm_config(config, name)?;
-    provision::provision(vm_conf, instance)
-        .await
-        .context("Provisioning failed")
+    provision::provision(vm_conf, instance, app_manifest).await
 }
 
 pub fn get_vm_config<'a>(config: &'a Config, name: &str) -> Result<&'a VmConfig> {

--- a/test-manager/src/vm/provision.rs
+++ b/test-manager/src/vm/provision.rs
@@ -1,11 +1,34 @@
-use crate::config::{Provisioner, VmConfig};
+use crate::config::{OsType, Provisioner, VmConfig};
+use crate::package;
 use anyhow::{Context, Result};
+use ssh2::Session;
+use std::fs::File;
+use std::io::{self, Read};
+use std::net::IpAddr;
+use std::net::TcpStream;
+use std::{net::SocketAddr, path::Path};
 
 pub async fn provision(
     config: &VmConfig,
-    _instance: &Box<dyn super::VmInstance>,
+    instance: &Box<dyn super::VmInstance>,
+    app_manifest: &package::Manifest,
 ) -> Result<String> {
     match config.provisioner {
+        Provisioner::Ssh => {
+            log::info!("SSH provisioning");
+
+            let (user, password) = config.get_ssh_options().context("missing SSH config")?;
+            ssh(
+                instance,
+                config.os_type,
+                config.get_runner_dir(),
+                app_manifest,
+                user,
+                password,
+            )
+            .await
+            .context("Failed to provision runner over SSH")
+        }
         Provisioner::Noop => {
             let dir = config
                 .artifacts_dir
@@ -14,4 +37,154 @@ pub async fn provision(
             Ok(dir.clone())
         }
     }
+}
+
+async fn ssh(
+    instance: &Box<dyn super::VmInstance>,
+    os_type: OsType,
+    local_runner_dir: &Path,
+    local_app_manifest: &package::Manifest,
+    user: &str,
+    password: &str,
+) -> Result<String> {
+    let guest_ip = *instance.get_ip();
+
+    let user = user.to_owned();
+    let password = password.to_owned();
+
+    let remote_dir = match os_type {
+        OsType::Windows => r"C:\testing",
+        OsType::Macos | OsType::Linux => r"/opt/testing",
+    };
+
+    let local_runner_dir = local_runner_dir.to_owned();
+    let local_app_manifest = local_app_manifest.to_owned();
+
+    tokio::task::spawn_blocking(move || {
+        blocking_ssh(
+            user,
+            password,
+            guest_ip,
+            &local_runner_dir,
+            local_app_manifest,
+            remote_dir,
+        )
+    })
+    .await
+    .context("Failed to join SSH task")??;
+
+    Ok(remote_dir.to_string())
+}
+
+fn blocking_ssh(
+    user: String,
+    password: String,
+    guest_ip: IpAddr,
+    local_runner_dir: &Path,
+    local_app_manifest: package::Manifest,
+    remote_dir: &str,
+) -> Result<()> {
+    // Directory that receives the payload. Any directory that the SSH user has access to.
+    const REMOTE_TEMP_DIR: &str = "/tmp/";
+    const SCRIPT_PAYLOAD: &[u8] = include_bytes!("../../../scripts/ssh-setup.sh");
+
+    let temp_dir = Path::new(REMOTE_TEMP_DIR);
+
+    let stream = TcpStream::connect(SocketAddr::new(guest_ip, 22)).context("TCP connect failed")?;
+
+    let mut session = Session::new().context("Failed to connect to SSH server")?;
+    session.set_tcp_stream(stream);
+    session.handshake()?;
+
+    session
+        .userauth_password(&user, &password)
+        .context("SSH auth failed")?;
+
+    // Transfer a test runner
+    let source = local_runner_dir.join("test-runner");
+    ssh_send_file_path(&session, &source, &temp_dir)
+        .context("Failed to send test runner to remote")?;
+
+    // Transfer app packages
+    ssh_send_file_path(&session, &local_app_manifest.current_app_path, &temp_dir)
+        .context("Failed to send current app package to remote")?;
+    ssh_send_file_path(&session, &local_app_manifest.previous_app_path, &temp_dir)
+        .context("Failed to send previous app package to remote")?;
+    ssh_send_file_path(&session, &local_app_manifest.ui_e2e_tests_path, &temp_dir)
+        .context("Failed to send UI test runner to remote")?;
+
+    // Transfer setup script
+    let dest = temp_dir.join("ssh-setup.sh");
+    log::debug!("Copying remote setup script -> {}", dest.display());
+    #[allow(const_item_mutation)]
+    ssh_send_file(
+        &session,
+        &mut SCRIPT_PAYLOAD,
+        u64::try_from(SCRIPT_PAYLOAD.len()).expect("script too long"),
+        &dest,
+    )
+    .context("failed to send test runner to remote")?;
+
+    // Run setup script
+
+    let args = format!(
+        "{remote_dir} \"{}\" \"{}\" \"{}\"",
+        local_app_manifest
+            .current_app_path
+            .file_name()
+            .unwrap()
+            .to_string_lossy(),
+        local_app_manifest
+            .previous_app_path
+            .file_name()
+            .unwrap()
+            .to_string_lossy(),
+        local_app_manifest
+            .ui_e2e_tests_path
+            .file_name()
+            .unwrap()
+            .to_string_lossy(),
+    );
+
+    log::debug!("Running setup script on remote, args: {args}");
+    ssh_exec(&session, &format!("sudo {} {args}", dest.display()))
+        .context("Failed to run setup script")
+}
+
+fn ssh_send_file_path(session: &Session, source: &Path, dest_dir: &Path) -> Result<()> {
+    let dest = dest_dir.join(source.file_name().context("Missing source file name")?);
+
+    log::debug!(
+        "Copying file to remote: {} -> {}",
+        source.display(),
+        dest.display(),
+    );
+
+    let mut file = File::open(source).context("Failed to open file")?;
+    let file_len = file.metadata().context("Failed to get file size")?.len();
+    ssh_send_file(&session, &mut file, file_len, &dest)
+}
+
+fn ssh_send_file<R: Read>(
+    session: &Session,
+    source: &mut R,
+    source_len: u64,
+    dest: &Path,
+) -> Result<()> {
+    let mut remote_file = session.scp_send(dest, 0o744, source_len, None)?;
+    io::copy(source, &mut remote_file).context("failed to write file")?;
+    remote_file.send_eof()?;
+    remote_file.wait_eof()?;
+    remote_file.close()?;
+    remote_file.wait_close()?;
+    Ok(())
+}
+
+fn ssh_exec(session: &Session, command: &str) -> Result<()> {
+    let mut channel = session.channel_session()?;
+    channel.exec(command)?;
+    channel.send_eof()?;
+    channel.wait_eof()?;
+    channel.wait_close()?;
+    Ok(())
 }

--- a/test-runner/src/main.rs
+++ b/test-runner/src/main.rs
@@ -3,7 +3,6 @@ use logging::LOGGER;
 use std::{
     net::{IpAddr, SocketAddr},
     path::Path,
-    time::Duration,
 };
 
 use tarpc::context;

--- a/test-runner/src/main.rs
+++ b/test-runner/src/main.rs
@@ -229,9 +229,8 @@ async fn main() -> Result<(), Error> {
     loop {
         log::info!("Connecting to {}", path);
 
-        let mut serial_stream =
+        let serial_stream =
             tokio_serial::SerialStream::open(&tokio_serial::new(&path, BAUD)).unwrap();
-        discard_partial_frames(&mut serial_stream).await;
         let (runner_transport, mullvad_daemon_transport, _completion_handle) =
             test_rpc::transport::create_server_transports(serial_stream);
 
@@ -246,21 +245,6 @@ async fn main() -> Result<(), Error> {
 
         log::error!("Restarting server since it stopped");
     }
-}
-
-// Try to discard partial frames. This actually discards all data, which should be safe since all of it
-// should be "ping" frames. If a "ping" is received simultaneously, this may still leave partial data,
-// but that is unlikely.
-async fn discard_partial_frames(serial_stream: &mut tokio_serial::SerialStream) {
-    let sleep = tokio::time::sleep(Duration::from_secs(1));
-    let discard_bytes = async {
-        while let Ok(bytes_read) = serial_stream.read(&mut [0u8; 2048]).await {
-            log::debug!("Discarded {bytes_read} bytes");
-        }
-    };
-    futures::pin_mut!(sleep);
-    futures::pin_mut!(discard_bytes);
-    futures::future::select(sleep, discard_bytes).await;
 }
 
 /// Forward data between the test manager and Mullvad management interface socket


### PR DESCRIPTION
This makes it possible to set up test runners over SSH if the base image does not include the service. Meaning that we don't necessarily need to use custom built images.

This only works on macOS at the moment.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app-tests/64)
<!-- Reviewable:end -->
