### PR TITLE
Add tests for quantum-resistant tunnels and multihop

### DIFF
--- a/BUILD_OS_IMAGE.md
+++ b/BUILD_OS_IMAGE.md
@@ -16,11 +16,11 @@ qemu-system-x86_64 -cpu host -accel kvm -m 4096 -smp 2 -cdrom debian-11.5.0-amd6
 ```
 
 `xvfb` must be installed on the host system. On Fedora, this package is called `xorg-x11-server-Xvfb`.
-On Debian/Ubuntu, the package is called `xvfb`. You may also need additional libraries. They are
-likely already installed if gnome is installed. On Debian:
+On Debian/Ubuntu, the package is called `xvfb`. You will also need `wireguard-tools`. You may also
+need additional libraries. They are likely already installed if gnome is installed. On Debian:
 
 ```bash
-apt install libnss3 libgbm1 libasound2 libatk1.0-0 libatk-bridge2.0-0 libcups2 libgtk-3-0
+apt install libnss3 libgbm1 libasound2 libatk1.0-0 libatk-bridge2.0-0 libcups2 libgtk-3-0 wireguard-tools
 ```
 
 ## Bootstrapping test runner

--- a/test-manager/src/tests/mod.rs
+++ b/test-manager/src/tests/mod.rs
@@ -118,6 +118,22 @@ pub async fn cleanup_after_test(
                     )
                     .await
                     .expect("Could not clear dns options in cleanup");
+                mullvad_client
+                    .set_quantum_resistant_tunnel(
+                        default_settings
+                            .tunnel_options
+                            .as_ref()
+                            .unwrap()
+                            .wireguard
+                            .as_ref()
+                            .unwrap()
+                            .quantum_resistant
+                            .as_ref()
+                            .unwrap()
+                            .clone(),
+                    )
+                    .await
+                    .expect("Could not clear PQ options in cleanup");
             }
 
             reset_relay_settings(&mut mullvad_client).await?;

--- a/test-manager/src/tests/tunnel.rs
+++ b/test-manager/src/tests/tunnel.rs
@@ -16,6 +16,7 @@ use mullvad_types::relay_constraints::{
 use pnet_packet::ip::IpNextHeaderProtocols;
 use talpid_types::net::{TransportProtocol, TunnelType};
 use test_macro::test_function;
+use test_rpc::meta::Os;
 use test_rpc::mullvad_daemon::ServiceStatus;
 use test_rpc::{Interface, ServiceClient};
 
@@ -447,4 +448,85 @@ pub async fn test_openvpn_autoconnect(
     .await?;
 
     Ok(())
+}
+
+/// Test whether quantum-resistant tunnels can be set up.
+///
+/// # Limitations
+///
+/// This only checks whether we have a working tunnel and a PSK. It does not determine whether the
+/// exchange part is correct.
+///
+/// We only check whether there is a PSK on Linux.
+#[test_function]
+pub async fn test_quantum_resistant_tunnel(
+    rpc: ServiceClient,
+    mut mullvad_client: ManagementServiceClient,
+) -> Result<(), Error> {
+    mullvad_client
+        .set_quantum_resistant_tunnel(types::QuantumResistantState {
+            state: i32::from(types::quantum_resistant_state::State::Off),
+        })
+        .await
+        .expect("Failed to enable PQ tunnels");
+
+    //
+    // PQ disabled: Find no "preshared key"
+    //
+
+    connect_and_wait(&mut mullvad_client).await?;
+    check_tunnel_psk(&rpc, false).await;
+
+    log::info!("Setting tunnel protocol to WireGuard");
+
+    let relay_settings = RelaySettingsUpdate::Normal(RelayConstraintsUpdate {
+        location: Some(Constraint::Only(LocationConstraint::Country(
+            "se".to_string(),
+        ))),
+        tunnel_protocol: Some(Constraint::Only(TunnelType::Wireguard)),
+        ..Default::default()
+    });
+
+    update_relay_settings(&mut mullvad_client, relay_settings)
+        .await
+        .expect("Failed to update relay settings");
+
+    mullvad_client
+        .set_quantum_resistant_tunnel(types::QuantumResistantState {
+            state: i32::from(types::quantum_resistant_state::State::On),
+        })
+        .await
+        .expect("Failed to enable PQ tunnels");
+
+    //
+    // PQ enabled: Find "preshared key"
+    //
+
+    connect_and_wait(&mut mullvad_client).await?;
+    check_tunnel_psk(&rpc, true).await;
+
+    Ok(())
+}
+
+async fn check_tunnel_psk(rpc: &ServiceClient, should_have_psk: bool) {
+    match rpc.get_os().await.expect("failed to get OS") {
+        Os::Linux => {
+            let name = rpc
+                .get_interface_name(Interface::Tunnel)
+                .await
+                .expect("failed to get tun name");
+            let output = rpc
+                .exec("wg", vec!["show", &name].into_iter())
+                .await
+                .expect("failed to run wg");
+            let parsed_output = std::str::from_utf8(&output.stdout).expect("non-utf8 output");
+            assert!(
+                parsed_output.contains("preshared key: ") == should_have_psk,
+                "expected to NOT find preshared key"
+            );
+        }
+        os => {
+            log::warn!("Not checking if there is a PSK on {os}");
+        }
+    }
 }

--- a/test-manager/src/tests/tunnel.rs
+++ b/test-manager/src/tests/tunnel.rs
@@ -530,3 +530,52 @@ async fn check_tunnel_psk(rpc: &ServiceClient, should_have_psk: bool) {
         }
     }
 }
+
+/// Test whether a PQ tunnel can be set up with multihop and UDP-over-TCP enabled.
+///
+/// # Limitations
+///
+/// This is not testing any of the individual components, just whether the daemon can connect when
+/// all of these features are combined.
+#[test_function]
+pub async fn test_quantum_resistant_multihop_udp2tcp_tunnel(
+    _rpc: ServiceClient,
+    mut mullvad_client: ManagementServiceClient,
+) -> Result<(), Error> {
+    mullvad_client
+        .set_quantum_resistant_tunnel(types::QuantumResistantState {
+            state: i32::from(types::quantum_resistant_state::State::On),
+        })
+        .await
+        .expect("Failed to enable PQ tunnels");
+
+    mullvad_client
+        .set_obfuscation_settings(types::ObfuscationSettings {
+            selected_obfuscation: i32::from(
+                types::obfuscation_settings::SelectedObfuscation::Udp2tcp,
+            ),
+            udp2tcp: Some(types::Udp2TcpObfuscationSettings { port: 0 }),
+        })
+        .await
+        .expect("Failed to enable obfuscation");
+
+    let relay_settings = RelaySettingsUpdate::Normal(RelayConstraintsUpdate {
+        location: Some(Constraint::Only(LocationConstraint::Country(
+            "se".to_string(),
+        ))),
+        wireguard_constraints: Some(WireguardConstraints {
+            use_multihop: true,
+            entry_location: Constraint::Only(LocationConstraint::Country("se".to_string())),
+            ..Default::default()
+        }),
+        ..Default::default()
+    });
+
+    update_relay_settings(&mut mullvad_client, relay_settings)
+        .await
+        .expect("Failed to update relay settings");
+
+    connect_and_wait(&mut mullvad_client).await?;
+
+    Ok(())
+}

--- a/test-rpc/src/client.rs
+++ b/test-rpc/src/client.rs
@@ -149,6 +149,13 @@ impl ServiceClient {
     }
 
     /// Returns the IP of the given interface.
+    pub async fn get_interface_name(&self, interface: Interface) -> Result<String, Error> {
+        self.client
+            .get_interface_name(tarpc::context::current(), interface)
+            .await?
+    }
+
+    /// Returns the IP of the given interface.
     pub async fn get_interface_ip(&self, interface: Interface) -> Result<IpAddr, Error> {
         self.client
             .get_interface_ip(tarpc::context::current(), interface)

--- a/test-rpc/src/lib.rs
+++ b/test-rpc/src/lib.rs
@@ -125,6 +125,9 @@ mod service {
         /// Fetch the current location.
         async fn geoip_lookup() -> Result<AmIMullvad, Error>;
 
+        /// Returns the name of the given interface.
+        async fn get_interface_name(interface: Interface) -> Result<String, Error>;
+
         /// Returns the IP of the given interface.
         async fn get_interface_ip(interface: Interface) -> Result<IpAddr, Error>;
 

--- a/test-rpc/src/meta.rs
+++ b/test-rpc/src/meta.rs
@@ -7,6 +7,16 @@ pub enum Os {
     Windows,
 }
 
+impl std::fmt::Display for Os {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Os::Linux => f.write_str("Linux"),
+            Os::Macos => f.write_str("macOS"),
+            Os::Windows => f.write_str("Windows"),
+        }
+    }
+}
+
 #[cfg(target_os = "linux")]
 pub const CURRENT_OS: Os = Os::Linux;
 

--- a/test-runner/src/main.rs
+++ b/test-runner/src/main.rs
@@ -154,6 +154,14 @@ impl Service for TestServer {
             .collect())
     }
 
+    async fn get_interface_name(
+        self,
+        _: context::Context,
+        interface: Interface,
+    ) -> Result<String, test_rpc::Error> {
+        Ok(net::get_interface_name(interface).to_owned())
+    }
+
     async fn get_interface_ip(
         self,
         _: context::Context,


### PR DESCRIPTION
Add a couple of tests:
1. Fail if the app fails to connect. On Linux, also sanity check whether the wireguard tunnel has a PSK set with `wg show wg-mullvad`.
2. Check if PQ works when multihop and udp-over-tcp are both enabled.

Other changes: Linux images must include `wireguard-tools` now.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app-tests/65)
<!-- Reviewable:end -->
