### PR TITLE
Add test attributes always_run and must_succeed-des-123

### DIFF
--- a/test-manager/src/tests/account.rs
+++ b/test-manager/src/tests/account.rs
@@ -12,7 +12,7 @@ use test_rpc::ServiceClient;
 const THROTTLE_RETRY_DELAY: Duration = Duration::from_secs(120);
 
 /// Log in and create a new device for the account.
-#[test_function(priority = -100)]
+#[test_function(always_run = true, must_succeed = true, priority = -100)]
 pub async fn test_login(
     _rpc: ServiceClient,
     mut mullvad_client: ManagementServiceClient,

--- a/test-manager/src/tests/install.rs
+++ b/test-manager/src/tests/install.rs
@@ -313,7 +313,7 @@ pub async fn test_uninstall_app(
 
 /// Install the app cleanly, failing if the installer doesn't succeed
 /// or if the VPN service is not running afterwards.
-#[test_function(priority = -160)]
+#[test_function(always_run = true, must_succeed = true, priority = -160)]
 pub async fn test_install_new_app(rpc: ServiceClient) -> Result<(), Error> {
     // verify that daemon is not already running
     if rpc.mullvad_daemon_get_status().await? != ServiceStatus::NotRunning {

--- a/test-manager/src/tests/test_metadata.rs
+++ b/test-manager/src/tests/test_metadata.rs
@@ -11,6 +11,8 @@ pub struct TestMetadata {
     pub mullvad_client_version: MullvadClientVersion,
     pub func: TestWrapperFunction,
     pub priority: Option<i32>,
+    pub always_run: bool,
+    pub must_succeed: bool,
 }
 
 // Register our test metadata struct with inventory to allow submitting tests of this type.


### PR DESCRIPTION
Tests can now be specified as always_run tests which will always run regardless of what filters are provided to the test framework. Test can also be specified as needing to succeed which means the test framework will stop running if the test fails.

Both of these default to false which means that filtering is practical and normal tests will run properly after installation and login has been done. It also means that if some test is temporarily failing due to external circumstances (such as some network service being down) will not cause the entire run to halt.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app-tests/67)
<!-- Reviewable:end -->
