### PR TITLE
Add VNC support to test manager (Linux/Windows)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -24,6 +24,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "addr2line"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a76fd60b23679b7d19bd066031410fb7e458ccc5e958eb5c325888ce4baedc97"
+dependencies = [
+ "gimli",
+]
+
+[[package]]
+name = "adler"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
+
+[[package]]
 name = "aead"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -82,6 +97,9 @@ name = "anyhow"
 version = "1.0.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "216261ddc8289130e551ddcd5ce8a064710c0d064a4d2895c67151c92b5443f6"
+dependencies = [
+ "backtrace",
+]
 
 [[package]]
 name = "async-stream"
@@ -185,6 +203,21 @@ dependencies = [
  "mime",
  "tower-layer",
  "tower-service",
+]
+
+[[package]]
+name = "backtrace"
+version = "0.3.67"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "233d376d6d185f2a3093e58f283f60f880315b6c60075b01f36b3b85154564ca"
+dependencies = [
+ "addr2line",
+ "cc",
+ "cfg-if",
+ "libc",
+ "miniz_oxide",
+ "object",
+ "rustc-demangle",
 ]
 
 [[package]]
@@ -892,6 +925,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "gimli"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad0a93d233ebf96623465aad4046a8d3aa4da22d4f4beba5388838c8a434bbb4"
+
+[[package]]
 name = "glob"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1398,6 +1437,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a60c7ce501c71e03a9c9c0d35b861413ae925bd979cc7a4e30d060069aaac8d"
 
 [[package]]
+name = "miniz_oxide"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b275950c28b37e794e8c55d88aeb5e139d0ce23fdbbeda68f8d7174abdf9e8fa"
+dependencies = [
+ "adler",
+]
+
+[[package]]
 name = "mio"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1640,6 +1688,15 @@ checksum = "f6058e64324c71e02bc2b150e4f3bc8286db6c83092132ffa3f6b1eab0f9def5"
 dependencies = [
  "hermit-abi 0.1.19",
  "libc",
+]
+
+[[package]]
+name = "object"
+version = "0.30.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea86265d3d3dcb6a27fc51bd29a4bf387fae9d2986b823079d4986af253eb439"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -2173,6 +2230,12 @@ name = "rs-release"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4a874cf4a0b9bc283edaa65d81d62368b84b1a8e56196e4885ca4701fd49972"
+
+[[package]]
+name = "rustc-demangle"
+version = "0.1.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ef03e0a2b150c7a90d01faf6254c9c48a41e95fb2a8c2ac1c6f0d2b9aefc342"
 
 [[package]]
 name = "rustc_version"

--- a/docs/REMOTE_MANAGEMENT.md
+++ b/docs/REMOTE_MANAGEMENT.md
@@ -2,13 +2,8 @@ You can connect to a guest VM remotely by forwarding a VNC server port over SSH.
 built-in VNC server. This example starts a Debian 11 VM as the `test` user:
 
 ```
-ssh -L 5933:127.0.0.1:5933 -tt $SSH_HOST \
-    "sudo -u test \
-    qemu-system-x86_64 -snapshot -cpu host -accel kvm -m 4096 -smp 2 \
-    -drive file="$TEST_APP_PATH/os-images/debian11.qcow2" \
-    -drive if=none,id=runner,file="$TEST_APP_PATH/testrunner-images/linux-test-runner.img" \
-    -device nec-usb-xhci,id=xhci -device usb-storage,drive=runner,bus=xhci.0 \
-    -display vnc=127.0.0.1:33"
+ssh -L 5933:127.0.0.1:5933 -tt $SSH_HOST "sudo -u test bash -c 'cd $TEST_APP_PATH; \
+    cargo run --bin test-manager run-vm debian11 --vnc 5933'"
 ```
 
 Replace `$SSH_HOST` with the server that you wish to connect to, and `$TEST_APP_PATH` with the path

--- a/test-manager/Cargo.toml
+++ b/test-manager/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-anyhow = "1"
+anyhow = { version = "1", features = ["backtrace"] }
 futures = "0.3"
 regex = "1"
 tarpc = { version = "0.30", features = ["tokio1", "serde-transport", "serde1"] }

--- a/test-manager/src/config.rs
+++ b/test-manager/src/config.rs
@@ -21,10 +21,22 @@ pub enum Error {
 #[derive(Default, Serialize, Deserialize, Clone)]
 pub struct Config {
     #[serde(skip)]
-    pub keep_changes: bool,
-    #[serde(skip)]
-    pub display: bool,
+    pub runtime_opts: RuntimeOptions,
     pub vms: BTreeMap<String, VmConfig>,
+}
+
+#[derive(Default, Serialize, Deserialize, Clone)]
+pub struct RuntimeOptions {
+    pub display: Display,
+    pub keep_changes: bool,
+}
+
+#[derive(Default, Serialize, Deserialize, Clone)]
+pub enum Display {
+    #[default]
+    None,
+    Local,
+    Vnc,
 }
 
 impl Config {


### PR DESCRIPTION
See `REMOTE_MANAGEMENT.md` for an explanation of how to use this. One limitation is that it is a bit flaky with tart right now, since we don't control the assigned port there. But I still haven't disabled the flag on macOS.

Completes DES-160.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app-tests/70)
<!-- Reviewable:end -->
