### PR TITLE
Add more notes about scheduled runner task on Windows

### DIFF
--- a/BUILD_OS_IMAGE.md
+++ b/BUILD_OS_IMAGE.md
@@ -166,6 +166,14 @@ This can be achieved as follows:
     schtasks /create /tn "Mullvad Test Runner" /sc onlogon /tr "\"E:\test-runner.exe\" \\.\COM1 serve" /rl highest
     ```
 
+    Further changes might be required to prevent the task from stopping unexpectedly. In the
+    Task Scheduler (`taskschd.msc`), change the following settings for the runner task:
+
+    * Disable "Start the task only if the computer is on AC power".
+    * Disable "Stop task if it runs longer than ...".
+    * Enable "Run task as soon as possible after a scheduled start is missed".
+    * Enable "If the task fails, restart every: 1 minute".
+
 * In the guest, disable Windows Update.
 
     * Open `services.msc`.


### PR DESCRIPTION
It seems like tasks by default are stopped if they run for too long. This PR just adds some more notes to the `BUILD_OS_IMAGE.md` for how to set up the scheduled task properly.

Fixes DES-146.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app-tests/71)
<!-- Reviewable:end -->
