### PR TITLE
Reset daemon state after failing tests

### DIFF
--- a/test-manager/src/mullvad_daemon.rs
+++ b/test-manager/src/mullvad_daemon.rs
@@ -66,7 +66,7 @@ impl RpcClientProvider {
         }
     }
 
-    async fn new_client(&self) -> ManagementServiceClient {
+    pub async fn new_client(&self) -> ManagementServiceClient {
         log::debug!("Mullvad daemon: connecting");
         let channel = tonic::transport::Endpoint::from_static("serial://placeholder")
             .timeout(GRPC_REQUEST_TIMEOUT)

--- a/test-manager/src/tests/test_metadata.rs
+++ b/test-manager/src/tests/test_metadata.rs
@@ -13,6 +13,7 @@ pub struct TestMetadata {
     pub priority: Option<i32>,
     pub always_run: bool,
     pub must_succeed: bool,
+    pub cleanup: bool,
 }
 
 // Register our test metadata struct with inventory to allow submitting tests of this type.

--- a/test-rpc/src/mullvad_daemon.rs
+++ b/test-rpc/src/mullvad_daemon.rs
@@ -20,7 +20,7 @@ pub enum ServiceStatus {
     Running,
 }
 
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, PartialEq)]
 pub enum MullvadClientVersion {
     None,
     New,


### PR DESCRIPTION
When we stopped treating all tests as `must_succeed`, the cleanup code was never updated. Fix by always running the cleanup code when a test fails.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app-tests/72)
<!-- Reviewable:end -->
