### PR TITLE
Clear cargo cache in CI script

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1522,20 +1522,20 @@ dependencies = [
 [[package]]
 name = "mullvad-management-interface"
 version = "0.0.0"
-source = "git+https://github.com/mullvad/mullvadvpn-app?rev=2023.2#ccfbaa279d04b4f93dff489880e3fb3ae67025bd"
+source = "git+https://github.com/mullvad/mullvadvpn-app?rev=2023.3#52bb628c9ef30e68789e02902cc91a40ea8824b5"
 dependencies = [
  "chrono",
  "err-derive",
  "futures",
  "lazy_static",
  "log",
- "mullvad-paths 0.0.0 (git+https://github.com/mullvad/mullvadvpn-app?rev=2023.2)",
- "mullvad-types 0.0.0 (git+https://github.com/mullvad/mullvadvpn-app?rev=2023.2)",
+ "mullvad-paths 0.0.0 (git+https://github.com/mullvad/mullvadvpn-app?rev=2023.3)",
+ "mullvad-types 0.0.0 (git+https://github.com/mullvad/mullvadvpn-app?rev=2023.3)",
  "nix 0.23.1",
  "parity-tokio-ipc",
  "prost",
  "prost-types",
- "talpid-types 0.0.0 (git+https://github.com/mullvad/mullvadvpn-app?rev=2023.2)",
+ "talpid-types 0.0.0 (git+https://github.com/mullvad/mullvadvpn-app?rev=2023.3)",
  "tokio",
  "tonic",
  "tonic-build",
@@ -1557,13 +1557,13 @@ dependencies = [
 [[package]]
 name = "mullvad-paths"
 version = "0.0.0"
-source = "git+https://github.com/mullvad/mullvadvpn-app?rev=2023.2#ccfbaa279d04b4f93dff489880e3fb3ae67025bd"
+source = "git+https://github.com/mullvad/mullvadvpn-app?rev=2023.3#52bb628c9ef30e68789e02902cc91a40ea8824b5"
 dependencies = [
  "err-derive",
  "log",
  "once_cell",
  "widestring",
- "windows-sys 0.42.0",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -1586,7 +1586,7 @@ dependencies = [
 [[package]]
 name = "mullvad-types"
 version = "0.0.0"
-source = "git+https://github.com/mullvad/mullvadvpn-app?rev=2023.2#ccfbaa279d04b4f93dff489880e3fb3ae67025bd"
+source = "git+https://github.com/mullvad/mullvadvpn-app?rev=2023.3#52bb628c9ef30e68789e02902cc91a40ea8824b5"
 dependencies = [
  "chrono",
  "err-derive",
@@ -1597,7 +1597,7 @@ dependencies = [
  "rand 0.8.5",
  "regex",
  "serde",
- "talpid-types 0.0.0 (git+https://github.com/mullvad/mullvadvpn-app?rev=2023.2)",
+ "talpid-types 0.0.0 (git+https://github.com/mullvad/mullvadvpn-app?rev=2023.3)",
 ]
 
 [[package]]
@@ -2710,7 +2710,7 @@ dependencies = [
 [[package]]
 name = "talpid-types"
 version = "0.0.0"
-source = "git+https://github.com/mullvad/mullvadvpn-app?rev=2023.2#ccfbaa279d04b4f93dff489880e3fb3ae67025bd"
+source = "git+https://github.com/mullvad/mullvadvpn-app?rev=2023.3#52bb628c9ef30e68789e02902cc91a40ea8824b5"
 dependencies = [
  "base64 0.13.1",
  "err-derive",
@@ -2814,7 +2814,7 @@ dependencies = [
  "log",
  "mullvad-api",
  "mullvad-management-interface 0.0.0 (git+https://github.com/mullvad/mullvadvpn-app?branch=main)",
- "mullvad-management-interface 0.0.0 (git+https://github.com/mullvad/mullvadvpn-app?rev=2023.2)",
+ "mullvad-management-interface 0.0.0 (git+https://github.com/mullvad/mullvadvpn-app?rev=2023.3)",
  "mullvad-types 0.0.0 (git+https://github.com/mullvad/mullvadvpn-app?branch=main)",
  "once_cell",
  "pcap",

--- a/test-manager/Cargo.toml
+++ b/test-manager/Cargo.toml
@@ -40,7 +40,7 @@ tonic = "0.8"
 tower = "0.4"
 colored = "2.0.0"
 mullvad-management-interface = { git = "https://github.com/mullvad/mullvadvpn-app", branch = "main" }
-old-mullvad-management-interface = { git = "https://github.com/mullvad/mullvadvpn-app", rev = "2023.2", package = "mullvad-management-interface" }
+old-mullvad-management-interface = { git = "https://github.com/mullvad/mullvadvpn-app", rev = "2023.3", package = "mullvad-management-interface", version = "0.0.0" }
 talpid-types = { git = "https://github.com/mullvad/mullvadvpn-app", branch = "main" }
 mullvad-types = { git = "https://github.com/mullvad/mullvadvpn-app", branch = "main" }
 mullvad-api = { git = "https://github.com/mullvad/mullvadvpn-app", branch = "main" }

--- a/test-manager/src/tests/install.rs
+++ b/test-manager/src/tests/install.rs
@@ -259,8 +259,6 @@ pub async fn test_uninstall_app(
     rpc: ServiceClient,
     mut mullvad_client: mullvad_management_interface::ManagementServiceClient,
 ) -> Result<(), Error> {
-    const THROTTLE_RETRY_DELAY: Duration = Duration::from_secs(120);
-
     if rpc.mullvad_daemon_get_status().await? != ServiceStatus::Running {
         return Err(Error::DaemonNotRunning);
     }


### PR DESCRIPTION
Rather than set an explicit commit hash, clear the cache. We need to do the latter because (1) it keeps growing indefinitely, and (2) cargo uses the cached version rather than the most recent commit on the branch.

Fixes DES-177.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app-tests/75)
<!-- Reviewable:end -->
