### PR TITLE
Hide successful test logs by default

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2801,6 +2801,7 @@ dependencies = [
  "async-tempfile",
  "async-trait",
  "bytes",
+ "chrono",
  "clap",
  "colored",
  "data-encoding-macro",

--- a/test-manager/Cargo.toml
+++ b/test-manager/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 anyhow = { version = "1", features = ["backtrace"] }
 futures = "0.3"
 regex = "1"
+chrono = "0.4"
 tarpc = { version = "0.30", features = ["tokio1", "serde-transport", "serde1"] }
 tokio = { version = "1.0", features = ["macros", "rt", "process", "time", "fs", "io-util", "rt-multi-thread"] }
 tokio-serial = "5.4.1"

--- a/test-manager/src/logging.rs
+++ b/test-manager/src/logging.rs
@@ -1,9 +1,9 @@
 use crate::tests::Error;
 use colored::Colorize;
 use futures::FutureExt;
+use std::panic;
 use std::sync::Mutex;
 use std::{future::Future, sync::Arc};
-use std::panic;
 use test_rpc::{
     logging::{LogOutput, Output},
     ServiceClient,
@@ -46,7 +46,7 @@ impl Logger {
                 inner: Arc::new(Mutex::new(LoggerInner {
                     env_logger,
                     buffer: false,
-                    stored_records: vec![]
+                    stored_records: vec![],
                 })),
             };
 
@@ -70,7 +70,10 @@ impl Logger {
     pub fn print_stored_records(&self) {
         let mut inner = self.inner.lock().unwrap();
         for stored_record in std::mem::take(&mut inner.stored_records) {
-            println!("[{} {} {}] {}", stored_record.time, stored_record.level, stored_record.mod_path, stored_record.text);
+            println!(
+                "[{} {} {}] {}",
+                stored_record.time, stored_record.level, stored_record.mod_path, stored_record.text
+            );
         }
     }
 

--- a/test-manager/src/main.rs
+++ b/test-manager/src/main.rs
@@ -90,6 +90,10 @@ enum Commands {
 
         /// Only run tests matching substrings
         test_filters: Vec<String>,
+
+        /// Print results live
+        #[arg(long, short)]
+        verbose: bool,
     },
 }
 
@@ -104,7 +108,7 @@ impl Args {
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    init_logger();
+    logging::Logger::get_or_init();
 
     let args = Args::parse();
 
@@ -169,6 +173,7 @@ async fn main() -> Result<()> {
             current_app,
             previous_app,
             test_filters,
+            verbose,
         } => {
             let mut config = config.clone();
             config.runtime_opts.display = match (display, vnc.is_some()) {
@@ -219,6 +224,7 @@ async fn main() -> Result<()> {
                 &*instance,
                 &test_filters,
                 skip_wait,
+                !verbose,
             )
             .await
             .context("Tests failed");
@@ -229,15 +235,4 @@ async fn main() -> Result<()> {
             result
         }
     }
-}
-
-fn init_logger() {
-    let mut logger = env_logger::Builder::new();
-    logger.filter_module("h2", log::LevelFilter::Info);
-    logger.filter_module("tower", log::LevelFilter::Info);
-    logger.filter_module("hyper", log::LevelFilter::Info);
-    logger.filter_module("rustls", log::LevelFilter::Info);
-    logger.filter_level(log::LevelFilter::Debug);
-    logger.parse_env(env_logger::DEFAULT_FILTER_ENV);
-    logger.init();
 }

--- a/test-manager/src/mullvad_daemon.rs
+++ b/test-manager/src/mullvad_daemon.rs
@@ -56,7 +56,6 @@ impl RpcClientProvider {
         &self,
         client_type: MullvadClientVersion,
     ) -> Box<dyn std::any::Any + Send> {
-
         match client_type {
             MullvadClientVersion::New => Box::new(self.new_client().await),
             MullvadClientVersion::Previous => Box::new(self.old_client().await),
@@ -195,5 +194,3 @@ pub async fn new_rpc_client(
 
     RpcClientProvider { service }
 }
-
-

--- a/test-manager/src/mullvad_daemon.rs
+++ b/test-manager/src/mullvad_daemon.rs
@@ -32,7 +32,7 @@ impl<Request> Service<Request> for DummyService {
     }
 
     fn call(&mut self, _: Request) -> Self::Future {
-        log::debug!("DummyService::call");
+        log::trace!("DummyService::call");
 
         let (channel_in, channel_out) = tokio::io::duplex(CONVERTER_BUF_SIZE);
         let notifier_tx = self.management_channel_provider_tx.clone();
@@ -74,7 +74,6 @@ impl RpcClientProvider {
             .connect_with_connector(self.service.clone())
             .await
             .unwrap();
-        log::debug!("Mullvad daemon: connected");
 
         ManagementServiceClient::new(channel)
     }
@@ -89,7 +88,6 @@ impl RpcClientProvider {
         .connect_with_connector(self.service.clone())
         .await
         .unwrap();
-        log::debug!("Mullvad daemon (old): connected");
 
         old_mullvad_management_interface::ManagementServiceClient::new(channel)
     }

--- a/test-manager/src/run_tests.rs
+++ b/test-manager/src/run_tests.rs
@@ -1,9 +1,9 @@
+use crate::tests::TestContext;
 use crate::{logging::run_test, mullvad_daemon, tests, vm};
 use anyhow::{Context, Result};
 use mullvad_management_interface::ManagementServiceClient;
 use std::time::Duration;
 use test_rpc::{mullvad_daemon::MullvadClientVersion, ServiceClient};
-use crate::tests::TestContext;
 
 const BAUD: u32 = 115200;
 
@@ -66,7 +66,10 @@ pub async fn run(
     let logger = super::logging::Logger::get_or_init();
 
     for test in tests {
-        let mut mclient = test_context.rpc_provider.as_type(test.mullvad_client_version).await;
+        let mut mclient = test_context
+            .rpc_provider
+            .as_type(test.mullvad_client_version)
+            .await;
 
         if let Some(client) = mclient.downcast_mut::<ManagementServiceClient>() {
             crate::tests::init_default_settings(client).await;
@@ -79,9 +82,15 @@ pub async fn run(
             logger.store_records(true);
         }
 
-        let test_result = run_test(client.clone(), mclient, &test.func, test.name, test_context.clone())
-            .await
-            .context("Failed to run test")?;
+        let test_result = run_test(
+            client.clone(),
+            mclient,
+            &test.func,
+            test.name,
+            test_context.clone(),
+        )
+        .await
+        .context("Failed to run test")?;
 
         if test.mullvad_client_version == MullvadClientVersion::New {
             // Try to reset the daemon state if the test failed OR if the test doesn't explicitly

--- a/test-manager/src/tests/account.rs
+++ b/test-manager/src/tests/account.rs
@@ -351,13 +351,10 @@ pub async fn test_automatic_wireguard_rotation(
         }
     };
 
-    let new_key = tokio::time::timeout(
-        KEY_ROTATION_TIMEOUT,
-        get_pub_key_event,
-    )
-    .await
-    .unwrap()
-    .unwrap();
+    let new_key = tokio::time::timeout(KEY_ROTATION_TIMEOUT, get_pub_key_event)
+        .await
+        .unwrap()
+        .unwrap();
 
     assert_ne!(old_key, new_key);
     Ok(())

--- a/test-manager/src/tests/account.rs
+++ b/test-manager/src/tests/account.rs
@@ -1,5 +1,5 @@
 use super::config::TEST_CONFIG;
-use super::{helpers::{self, connect_and_wait}, ui, Error, TestContext};
+use super::{helpers, ui, Error, TestContext};
 use mullvad_api::DevicesProxy;
 use mullvad_management_interface::{types, Code, ManagementServiceClient};
 use mullvad_types::device::Device;

--- a/test-manager/src/tests/install.rs
+++ b/test-manager/src/tests/install.rs
@@ -310,7 +310,8 @@ pub async fn test_install_new_app(_: TestContext, rpc: ServiceClient) -> Result<
         .await?;
 
     // Set the log level to trace
-    rpc.set_daemon_log_level(test_rpc::mullvad_daemon::Verbosity::Trace).await?;
+    rpc.set_daemon_log_level(test_rpc::mullvad_daemon::Verbosity::Trace)
+        .await?;
 
     // verify that daemon is running
     if rpc.mullvad_daemon_get_status().await? != ServiceStatus::Running {

--- a/test-manager/src/tests/mod.rs
+++ b/test-manager/src/tests/mod.rs
@@ -9,8 +9,8 @@ mod tunnel;
 mod tunnel_state;
 mod ui;
 
-use anyhow::Context;
 use crate::mullvad_daemon::RpcClientProvider;
+use anyhow::Context;
 use helpers::reset_relay_settings;
 pub use test_metadata::TestMetadata;
 use test_rpc::ServiceClient;
@@ -30,7 +30,11 @@ pub struct TestContext {
 }
 
 pub type TestWrapperFunction = Box<
-    dyn Fn(TestContext, ServiceClient, Box<dyn std::any::Any + Send>) -> BoxFuture<'static, Result<(), Error>>,
+    dyn Fn(
+        TestContext,
+        ServiceClient,
+        Box<dyn std::any::Any + Send>,
+    ) -> BoxFuture<'static, Result<(), Error>>,
 >;
 
 #[derive(err_derive::Error, Debug, PartialEq, Eq)]

--- a/test-manager/src/tests/settings.rs
+++ b/test-manager/src/tests/settings.rs
@@ -1,7 +1,7 @@
 use super::helpers::{
     connect_and_wait, disconnect_and_wait, get_tunnel_state, ping_with_timeout, send_guest_probes,
 };
-use super::{TestContext, Error};
+use super::{Error, TestContext};
 use crate::assert_tunnel_state;
 
 use mullvad_management_interface::ManagementServiceClient;

--- a/test-manager/src/tests/test_metadata.rs
+++ b/test-manager/src/tests/test_metadata.rs
@@ -1,5 +1,5 @@
-use test_rpc::mullvad_daemon::MullvadClientVersion;
 use super::TestWrapperFunction;
+use test_rpc::mullvad_daemon::MullvadClientVersion;
 
 pub struct TestMetadata {
     pub name: &'static str,

--- a/test-manager/src/tests/tunnel.rs
+++ b/test-manager/src/tests/tunnel.rs
@@ -4,7 +4,7 @@ use super::helpers::{
     self, connect_and_wait, disconnect_and_wait, geoip_lookup_with_retries, ping_with_timeout,
     update_relay_settings,
 };
-use super::{TestContext, Error};
+use super::{Error, TestContext};
 
 use crate::network_monitor::{start_packet_monitor, MonitorOptions};
 use mullvad_management_interface::{types, ManagementServiceClient};

--- a/test-rpc/src/client.rs
+++ b/test-rpc/src/client.rs
@@ -188,7 +188,10 @@ impl ServiceClient {
             .await?
     }
 
-    pub async fn set_daemon_log_level(&self, verbosity_level: mullvad_daemon::Verbosity) -> Result<(), Error> {
+    pub async fn set_daemon_log_level(
+        &self,
+        verbosity_level: mullvad_daemon::Verbosity,
+    ) -> Result<(), Error> {
         let mut ctx = tarpc::context::current();
         ctx.deadline = SystemTime::now().checked_add(LOG_LEVEL_TIMEOUT).unwrap();
         self.client
@@ -212,12 +215,14 @@ impl ServiceClient {
     }
 
     pub async fn set_mullvad_daemon_service_state(&self, on: bool) -> Result<(), Error> {
-        self.client.set_mullvad_daemon_service_state(tarpc::context::current(), on).await?
+        self.client
+            .set_mullvad_daemon_service_state(tarpc::context::current(), on)
+            .await?
     }
 
     pub async fn make_device_json_old(&self) -> Result<(), Error> {
-        self.client.make_device_json_old(tarpc::context::current()).await?
+        self.client
+            .make_device_json_old(tarpc::context::current())
+            .await?
     }
 }
-
-

--- a/test-rpc/src/lib.rs
+++ b/test-rpc/src/lib.rs
@@ -149,7 +149,9 @@ mod service {
 
         /// Sets the log level of the daemon service, the verbosity level represents the number of
         /// `-v`s passed on the command line. This will restart the daemon system service.
-        async fn set_daemon_log_level(verbosity_level: mullvad_daemon::Verbosity) -> Result<(), Error>;
+        async fn set_daemon_log_level(
+            verbosity_level: mullvad_daemon::Verbosity,
+        ) -> Result<(), Error>;
 
         async fn reboot() -> Result<(), Error>;
 
@@ -161,5 +163,3 @@ mod service {
 
 pub use client::ServiceClient;
 pub use service::{Service, ServiceRequest, ServiceResponse};
-
-

--- a/test-runner/src/main.rs
+++ b/test-runner/src/main.rs
@@ -215,7 +215,11 @@ impl Service for TestServer {
         logging::get_mullvad_app_logs().await
     }
 
-    async fn set_daemon_log_level(self, _: context::Context, verbosity_level: test_rpc::mullvad_daemon::Verbosity) -> Result<(), test_rpc::Error> {
+    async fn set_daemon_log_level(
+        self,
+        _: context::Context,
+        verbosity_level: test_rpc::mullvad_daemon::Verbosity,
+    ) -> Result<(), test_rpc::Error> {
         sys::set_daemon_log_level(verbosity_level).await
     }
 
@@ -223,7 +227,11 @@ impl Service for TestServer {
         sys::reboot()
     }
 
-    async fn set_mullvad_daemon_service_state(self, _: context::Context, on: bool) -> Result<(), test_rpc::Error> {
+    async fn set_mullvad_daemon_service_state(
+        self,
+        _: context::Context,
+        on: bool,
+    ) -> Result<(), test_rpc::Error> {
         sys::set_mullvad_daemon_service_state(on).await
     }
 
@@ -355,9 +363,7 @@ async fn forward_to_mullvad_daemon_interface(proxy_transport: GrpcForwarder) {
                         log::error!("daemon client channel error: {error}");
                         break;
                     }
-                    None => {
-                        break
-                    },
+                    None => break,
                 },
             }
         }

--- a/test-runner/src/sys.rs
+++ b/test-runner/src/sys.rs
@@ -365,7 +365,8 @@ async fn wait_for_service_state(awaited_state: ServiceState) -> Result<(), test_
             .args(["status", "mullvad-daemon"])
             .output()
             .await
-            .map_err(|e| test_rpc::Error::Service(e.to_string()))?.stdout;
+            .map_err(|e| test_rpc::Error::Service(e.to_string()))?
+            .stdout;
         let output = String::from_utf8_lossy(&output);
 
         match awaited_state {


### PR DESCRIPTION
Add a `--verbose` option to `run-tests`. By default, this is disabled and log output is suppressed for successful tests.

Fixes DES-196.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app-tests/76)
<!-- Reviewable:end -->
