### PR TITLE
Cleanup/clippy again

### DIFF
--- a/test-manager/src/main.rs
+++ b/test-manager/src/main.rs
@@ -199,7 +199,7 @@ async fn main() -> Result<()> {
             let mut instance = vm::run(&config, &name)
                 .await
                 .context("Failed to start VM")?;
-            let artifacts_dir = vm::provision(&config, &name, &instance, &manifest)
+            let artifacts_dir = vm::provision(&config, &name, &*instance, &manifest)
                 .await
                 .context("Failed to run provisioning for VM")?;
 

--- a/test-manager/src/package.rs
+++ b/test-manager/src/package.rs
@@ -5,7 +5,7 @@ use regex::Regex;
 use std::path::{Path, PathBuf};
 use tokio::fs;
 
-const VERSION_REGEX: Lazy<Regex> =
+static VERSION_REGEX: Lazy<Regex> =
     Lazy::new(|| Regex::new(r"\d{4}\.\d+(-beta\d+)?(-dev)?-([0-9a-z])+").unwrap());
 
 #[derive(Debug, Clone)]
@@ -96,19 +96,17 @@ async fn find_app(
         }
 
         // Filter out irrelevant platforms
-        if e2e_bin {
-            if !u8_path.contains(get_os_name(package_type)) {
-                continue;
-            }
+        if e2e_bin && !u8_path.contains(get_os_name(package_type)) {
+            continue;
         }
 
         // Skip file if it doesn't match the architecture
         if let Some(arch) = package_type.2 {
             // Skip for non-e2e bin on non-Linux, because there's only one package
-            if e2e_bin || package_type.0 == OsType::Linux {
-                if !arch.get_identifiers().iter().any(|id| u8_path.contains(id)) {
-                    continue;
-                }
+            if (e2e_bin || package_type.0 == OsType::Linux)
+                && !arch.get_identifiers().iter().any(|id| u8_path.contains(id))
+            {
+                continue;
             }
         }
 

--- a/test-manager/src/tests/dns.rs
+++ b/test-manager/src/tests/dns.rs
@@ -212,39 +212,39 @@ async fn leak_test_dns(
     // on port 53, and only inside the desired interface.
 
     spoof_packets(
-        &rpc,
+        rpc,
         Some(Interface::Tunnel),
         tun_bind_addr,
         whitelisted_dest,
     );
     spoof_packets(
-        &rpc,
+        rpc,
         Some(Interface::NonTunnel),
         guest_bind_addr,
         whitelisted_dest,
     );
 
     spoof_packets(
-        &rpc,
+        rpc,
         Some(Interface::Tunnel),
         tun_bind_addr,
         blocked_dest_local,
     );
     spoof_packets(
-        &rpc,
+        rpc,
         Some(Interface::NonTunnel),
         guest_bind_addr,
         blocked_dest_local,
     );
 
     spoof_packets(
-        &rpc,
+        rpc,
         Some(Interface::Tunnel),
         tun_bind_addr,
         blocked_dest_public,
     );
     spoof_packets(
-        &rpc,
+        rpc,
         Some(Interface::NonTunnel),
         guest_bind_addr,
         blocked_dest_public,

--- a/test-manager/src/vm/mod.rs
+++ b/test-manager/src/vm/mod.rs
@@ -59,7 +59,7 @@ pub async fn run(config: &Config, name: &str) -> Result<Box<dyn VmInstance>> {
 pub async fn provision(
     config: &Config,
     name: &str,
-    instance: &Box<dyn VmInstance>,
+    instance: &dyn VmInstance,
     app_manifest: &package::Manifest,
 ) -> Result<String> {
     let vm_conf = get_vm_config(config, name)?;

--- a/test-manager/src/vm/network/linux.rs
+++ b/test-manager/src/vm/network/linux.rs
@@ -13,7 +13,7 @@ use tokio::{
 };
 
 /// (Contained) test subnet for the test runner: 172.29.1.1/24
-pub const TEST_SUBNET: Lazy<Ipv4Network> =
+pub static TEST_SUBNET: Lazy<Ipv4Network> =
     Lazy::new(|| Ipv4Network::new(Ipv4Addr::new(172, 29, 1, 1), 24).unwrap());
 /// Range of IPs returned by the DNS server: TEST_SUBNET_DHCP_FIRST to TEST_SUBNET_DHCP_LAST
 pub const TEST_SUBNET_DHCP_FIRST: Ipv4Addr = Ipv4Addr::new(172, 29, 1, 2);

--- a/test-manager/src/vm/provision.rs
+++ b/test-manager/src/vm/provision.rs
@@ -10,7 +10,7 @@ use std::{net::SocketAddr, path::Path};
 
 pub async fn provision(
     config: &VmConfig,
-    instance: &Box<dyn super::VmInstance>,
+    instance: &dyn super::VmInstance,
     app_manifest: &package::Manifest,
 ) -> Result<String> {
     match config.provisioner {
@@ -40,7 +40,7 @@ pub async fn provision(
 }
 
 async fn ssh(
-    instance: &Box<dyn super::VmInstance>,
+    instance: &dyn super::VmInstance,
     os_type: OsType,
     local_runner_dir: &Path,
     local_app_manifest: &package::Manifest,
@@ -103,15 +103,15 @@ fn blocking_ssh(
 
     // Transfer a test runner
     let source = local_runner_dir.join("test-runner");
-    ssh_send_file_path(&session, &source, &temp_dir)
+    ssh_send_file_path(&session, &source, temp_dir)
         .context("Failed to send test runner to remote")?;
 
     // Transfer app packages
-    ssh_send_file_path(&session, &local_app_manifest.current_app_path, &temp_dir)
+    ssh_send_file_path(&session, &local_app_manifest.current_app_path, temp_dir)
         .context("Failed to send current app package to remote")?;
-    ssh_send_file_path(&session, &local_app_manifest.previous_app_path, &temp_dir)
+    ssh_send_file_path(&session, &local_app_manifest.previous_app_path, temp_dir)
         .context("Failed to send previous app package to remote")?;
-    ssh_send_file_path(&session, &local_app_manifest.ui_e2e_tests_path, &temp_dir)
+    ssh_send_file_path(&session, &local_app_manifest.ui_e2e_tests_path, temp_dir)
         .context("Failed to send UI test runner to remote")?;
 
     // Transfer openvpn cert
@@ -175,7 +175,7 @@ fn ssh_send_file_path(session: &Session, source: &Path, dest_dir: &Path) -> Resu
 
     let mut file = File::open(source).context("Failed to open file")?;
     let file_len = file.metadata().context("Failed to get file size")?.len();
-    ssh_send_file(&session, &mut file, file_len, &dest)
+    ssh_send_file(session, &mut file, file_len, &dest)
 }
 
 fn ssh_send_file<R: Read>(

--- a/test-manager/src/vm/qemu.rs
+++ b/test-manager/src/vm/qemu.rs
@@ -354,5 +354,5 @@ impl Drop for TempDir {
 }
 
 fn random_tempfile_name() -> PathBuf {
-    std::env::temp_dir().join(format!("tmp{}", Uuid::new_v4().to_string()))
+    std::env::temp_dir().join(format!("tmp{}", Uuid::new_v4()))
 }

--- a/test-manager/src/vm/tart.rs
+++ b/test-manager/src/vm/tart.rs
@@ -149,7 +149,7 @@ impl MachineCopy {
 
     /// Clone an existing VM and destroy changes when self is dropped.
     pub async fn clone_vm(name: &str) -> Result<Self> {
-        let clone_name = format!("test-{}", Uuid::new_v4().to_string());
+        let clone_name = format!("test-{}", Uuid::new_v4());
 
         let mut tart_cmd = Command::new("tart");
         tart_cmd.args(["clone", name, &clone_name]);

--- a/test-rpc/src/net.rs
+++ b/test-rpc/src/net.rs
@@ -7,7 +7,7 @@ use crate::{AmIMullvad, Error};
 
 const LE_ROOT_CERT: &[u8] = include_bytes!("./le_root_cert.pem");
 
-const CLIENT_CONFIG: Lazy<ClientConfig> = Lazy::new(|| {
+static CLIENT_CONFIG: Lazy<ClientConfig> = Lazy::new(|| {
     ClientConfig::builder()
         .with_safe_default_cipher_suites()
         .with_safe_default_kx_groups()

--- a/test-runner/src/main.rs
+++ b/test-runner/src/main.rs
@@ -337,7 +337,7 @@ async fn forward_to_mullvad_daemon_interface(proxy_transport: GrpcForwarder) {
                 Err(error) => {
                     log::error!("mullvad daemon: failed to connect: {error}");
                     // send EOF
-                    let _ = proxy_transport.send(bytes::Bytes::new());
+                    let _ = proxy_transport.send(bytes::Bytes::new()).await;
                     continue;
                 }
             };


### PR DESCRIPTION
This PR addresses most `clippy` warnings in the repo [(except one special kind which we might want to disable)](https://rust-lang.github.io/rust-clippy/master/index.html#enum_variant_names).

The rationale for merging this PR is to lower the barrier of introducing a CI job for checking `clippy` lints :blush:

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app-tests/78)
<!-- Reviewable:end -->
