### PR TITLE
Update vms before running tests (if possible)

### DIFF
--- a/test-manager/src/main.rs
+++ b/test-manager/src/main.rs
@@ -109,6 +109,16 @@ enum Commands {
         /// One or more test reports output by 'test-manager run-tests --test-report'
         reports: Vec<PathBuf>,
     },
+
+    /// Update the system image
+    ///
+    /// Note that in order for the updates to take place, the VM's config need
+    /// to have `provisioner` set to `ssh`, `ssh_user` & `ssh_password` set and
+    /// the `ssh_user` should be able to execute commands with sudo/ as root.
+    Update {
+        /// Name of the runner config
+        name: String,
+    },
 }
 
 impl Args {
@@ -176,7 +186,9 @@ async fn main() -> Result<()> {
             let mut instance = vm::run(&config, &name)
                 .await
                 .context("Failed to start VM")?;
+
             instance.wait().await;
+
             Ok(())
         }
         Commands::RunTests {
@@ -271,6 +283,21 @@ async fn main() -> Result<()> {
             summary::print_summary_table(&reports)
                 .await
                 .context("Print report")?;
+            Ok(())
+        }
+        Commands::Update { name } => {
+            let vm_config = vm::get_vm_config(&config, &name).context("Cannot get VM config")?;
+
+            let instance = vm::run(&config, &name)
+                .await
+                .context("Failed to start VM")?;
+
+            let update_output = vm::update_packages(vm_config.clone(), &*instance)
+                .await
+                .context("Failed to update packages to the VM image")?;
+            log::info!("Update command finished with output: {}", &update_output);
+            // TODO: If the update was successful, commit the changes to the VM image.
+            log::info!("Note: updates have not been persisted to the image");
             Ok(())
         }
     }

--- a/test-manager/src/vm/mod.rs
+++ b/test-manager/src/vm/mod.rs
@@ -9,7 +9,9 @@ mod logging;
 pub mod network;
 mod provision;
 mod qemu;
+mod ssh;
 mod tart;
+mod update;
 mod util;
 
 #[async_trait::async_trait]
@@ -62,8 +64,16 @@ pub async fn provision(
     instance: &dyn VmInstance,
     app_manifest: &package::Manifest,
 ) -> Result<String> {
-    let vm_conf = get_vm_config(config, name)?;
-    provision::provision(vm_conf, instance, app_manifest).await
+    let vm_config = get_vm_config(config, name)?;
+    provision::provision(vm_config, instance, app_manifest).await
+}
+
+pub async fn update_packages(
+    config: VmConfig,
+    instance: &dyn VmInstance,
+) -> Result<crate::vm::update::Update> {
+    let guest_ip = *instance.get_ip();
+    tokio::task::spawn_blocking(move || update::packages(&config, guest_ip)).await?
 }
 
 pub fn get_vm_config<'a>(config: &'a Config, name: &str) -> Result<&'a VmConfig> {

--- a/test-manager/src/vm/ssh.rs
+++ b/test-manager/src/vm/ssh.rs
@@ -1,0 +1,45 @@
+/// A very thin wrapper on top of `ssh2`.
+use anyhow::{Context, Result};
+use ssh2::Session;
+use std::io::Read;
+use std::net::{IpAddr, SocketAddr, TcpStream};
+
+/// Default `ssh` port.
+const PORT: u16 = 22;
+
+/// Handle to an `ssh` session.
+pub struct SSHSession {
+    session: ssh2::Session,
+}
+
+impl SSHSession {
+    /// Create a new `ssh` session.
+    /// This function is blocking while connecting.
+    ///
+    /// The tunnel is closed when the `SSHSession` is dropped.
+    pub fn connect(username: String, password: String, ip: IpAddr) -> Result<Self> {
+        // Set up the SSH connection
+        log::info!("initializing a new SSH session ..");
+        let stream = TcpStream::connect(SocketAddr::new(ip, PORT)).context("TCP connect failed")?;
+        let mut session = Session::new().context("Failed to connect to SSH server")?;
+        session.set_tcp_stream(stream);
+        session.handshake()?;
+        session
+            .userauth_password(&username, &password)
+            .context("SSH auth failed")?;
+        Ok(Self { session })
+    }
+
+    /// Execute an arbitrary string of commands via ssh.
+    pub fn exec_blocking(&self, command: &str) -> Result<String> {
+        let session = &self.session;
+        let mut channel = session.channel_session()?;
+        channel.exec(command)?;
+        let mut output = String::new();
+        channel.read_to_string(&mut output)?;
+        channel.send_eof()?;
+        channel.wait_eof()?;
+        channel.wait_close()?;
+        Ok(output)
+    }
+}

--- a/test-manager/src/vm/update.rs
+++ b/test-manager/src/vm/update.rs
@@ -1,0 +1,70 @@
+use crate::config::{OsType, PackageType, Provisioner, VmConfig};
+use crate::vm::ssh::SSHSession;
+use anyhow::{Context, Result};
+use std::fmt;
+
+#[derive(Debug)]
+pub enum Update {
+    Logs(Vec<String>),
+    Nothing,
+}
+
+/// Update system packages in a VM.
+///
+/// Note that this function is blocking.
+pub fn packages(config: &VmConfig, guest_ip: std::net::IpAddr) -> Result<Update> {
+    match config.provisioner {
+        Provisioner::Noop => return Ok(Update::Nothing),
+        Provisioner::Ssh => (),
+    }
+    // User SSH session to execute package manager update command.
+    // This will of course be dependant on the target platform.
+    let commands = match (config.os_type, config.package_type) {
+        (OsType::Linux, Some(PackageType::Deb)) => {
+            Some(vec!["sudo apt-get update", "sudo apt-get upgrade"])
+        }
+        (OsType::Linux, Some(PackageType::Rpm)) => Some(vec!["sudo dnf update"]),
+        (OsType::Linux, _) => None,
+        (OsType::Macos | OsType::Windows, _) => None,
+    };
+
+    // Issue the update command(s).
+    let result = match commands {
+        None => {
+            log::info!("No update command was found");
+            log::debug!(
+                "Tried to invoke package update for platform {:?} with package type {:?}",
+                config.os_type,
+                config.package_type
+            );
+            Update::Nothing
+        }
+        Some(commands) => {
+            log::info!("retrieving SSH credentials");
+            let (username, password) = config.get_ssh_options().context("missing SSH config")?;
+            let ssh = SSHSession::connect(username.to_string(), password.to_string(), guest_ip)?;
+            let output: Result<Vec<_>> = commands
+                .iter()
+                .map(|command| {
+                    log::info!("Running {command} in guest");
+                    ssh.exec_blocking(command)
+                })
+                .collect();
+            Update::Logs(output?)
+        }
+    };
+
+    Ok(result)
+}
+
+// Pretty-printing for an `Update` action.
+impl fmt::Display for Update {
+    fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            Update::Nothing => write!(formatter, "Nothing was updated"),
+            Update::Logs(output) => output
+                .iter()
+                .try_for_each(|output| formatter.write_str(output)),
+        }
+    }
+}


### PR DESCRIPTION
In VM images where there are known package managers (e.g. `apt` in Ubuntu/Debian, `dnf` in Fedora) we could allow for automatically updating system packages before proceeding with running tests.

This PR adds the `--update` flag to the `test-manager` CLI. If the flag is set, the VM's package manager is invoked with an update/upgrade request.

Note that these updates are not persisted in the VM image as of yet

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app-tests/85)
<!-- Reviewable:end -->
