### PR TITLE
Implement a generic connection check strategy

### DIFF
--- a/test-manager/src/tests/helpers.rs
+++ b/test-manager/src/tests/helpers.rs
@@ -339,7 +339,7 @@ pub async fn wait_for_mullvad_service_state(
     }
 }
 
-pub async fn geoip_lookup_with_retries(rpc: ServiceClient) -> Result<AmIMullvad, Error> {
+pub async fn geoip_lookup_with_retries(rpc: &ServiceClient) -> Result<AmIMullvad, Error> {
     const MAX_ATTEMPTS: usize = 5;
     const BEFORE_RETRY_DELAY: Duration = Duration::from_secs(2);
 

--- a/test-manager/src/tests/tunnel_state.rs
+++ b/test-manager/src/tests/tunnel_state.rs
@@ -1,6 +1,6 @@
 use super::helpers::{
-    connect_and_wait, disconnect_and_wait, get_tunnel_state, ping_with_timeout, send_guest_probes,
-    unreachable_wireguard_tunnel, update_relay_settings, wait_for_tunnel_state,
+    connect_and_wait, disconnect_and_wait, geoip_lookup_with_retries, get_tunnel_state,
+    send_guest_probes, unreachable_wireguard_tunnel, update_relay_settings, wait_for_tunnel_state,
 };
 use super::{ui, Error, TestContext};
 use crate::assert_tunnel_state;
@@ -277,12 +277,13 @@ pub async fn test_connected_state(
 
     log::info!("Select relay");
 
+    const RELAY_HOSTNAME: &str = "se-got-wg-001";
     let relay_settings = RelaySettingsUpdate::Normal(RelayConstraintsUpdate {
         location: Some(Constraint::Only(LocationConstraint::Location(
             GeographicLocationConstraint::Hostname(
                 "se".to_string(),
                 "got".to_string(),
-                "se-got-wg-001".to_string(),
+                RELAY_HOSTNAME.to_string(),
             ),
         ))),
         ..Default::default()
@@ -343,15 +344,14 @@ pub async fn test_connected_state(
         "observed unexpected outgoing packets"
     );
 
-    //
-    // Ping inside tunnel while connected
-    //
-
-    log::info!("Ping inside tunnel");
-
-    ping_with_timeout(&rpc, inet_destination.ip(), Some(Interface::Tunnel))
-        .await
-        .unwrap();
+    // Send traffic through the tunnel to sanity check that the internet is reachable.
+    log::info!("Test whether tunnel traffic works");
+    let geoip_lookup = geoip_lookup_with_retries(&rpc).await.unwrap();
+    assert!(geoip_lookup.mullvad_exit_ip, "Exit ip is not from Mullvad");
+    assert_eq!(
+        geoip_lookup.mullvad_exit_ip_hostname,
+        RELAY_HOSTNAME.to_string()
+    );
 
     disconnect_and_wait(&mut mullvad_client).await?;
 


### PR DESCRIPTION
As part of our automated tests, we want to assure that the internet is reachable through the VPN tunnel. To verify connectivity, we can request internet resources which are not the currently connected relay. Also, try something more elaborate than a ping (i.e. check for HTTP `200` from `am.i.mullvad.net`).

This is prone to network failures, which is why we retry each request 3 times before we consider it a failure.

## TODO
Use the strategy in actual tests

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app-tests/87)
<!-- Reviewable:end -->
