### PR TITLE
Update PATH before running UI tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3210,6 +3210,7 @@ dependencies = [
  "tokio-util",
  "windows-service",
  "windows-sys 0.45.0",
+ "winreg",
 ]
 
 [[package]]

--- a/test-rpc/src/lib.rs
+++ b/test-rpc/src/lib.rs
@@ -39,7 +39,7 @@ pub enum Error {
     SendTcp,
     #[error(display = "Failed to send ping")]
     Ping,
-    #[error(display = "Failed to set registry value")]
+    #[error(display = "Failed to get or set registry value")]
     Registry(String),
     #[error(display = "Failed to change the service")]
     Service(String),

--- a/test-runner/Cargo.toml
+++ b/test-runner/Cargo.toml
@@ -32,6 +32,7 @@ socket2 = { version = "0.5", features = ["all"] }
 talpid-windows-net = { git = "https://github.com/mullvad/mullvadvpn-app", branch = "main" }
 
 windows-service = "0.6"
+winreg = "0.50"
 
 [target.'cfg(windows)'.dependencies.windows-sys]
 version = "0.45.0"

--- a/test-runner/src/main.rs
+++ b/test-runner/src/main.rs
@@ -72,6 +72,12 @@ impl Service for TestServer {
 
         let mut cmd = Command::new(&path);
         cmd.args(args);
+
+        // Make sure that PATH is updated
+        // TODO: We currently do not need this on non-Windows
+        #[cfg(target_os = "windows")]
+        cmd.env("PATH", sys::get_system_path_var()?);
+
         cmd.envs(env);
 
         let output = cmd.output().await.map_err(|error| {


### PR DESCRIPTION
The app resource directory is not necessarily in `PATH` when the test runner starts, since it isn't initially installed. This causes some UI tests to fail.

This PR works around this problem by always running `exec` with an updated `PATH` var.

Currently, this is only done on Windows, because we don't need to make any changes to `PATH` on other OSes.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app-tests/92)
<!-- Reviewable:end -->
