### PR TITLE
Clean up remaining `clippy` warnings

### DIFF
--- a/test-manager/src/main.rs
+++ b/test-manager/src/main.rs
@@ -121,6 +121,7 @@ enum Commands {
     },
 }
 
+#[cfg(target_os = "linux")]
 impl Args {
     fn get_vnc_port(&self) -> Option<u16> {
         match self.cmd {

--- a/test-manager/src/tests/tunnel_state.rs
+++ b/test-manager/src/tests/tunnel_state.rs
@@ -348,10 +348,7 @@ pub async fn test_connected_state(
     log::info!("Test whether tunnel traffic works");
     let geoip_lookup = geoip_lookup_with_retries(&rpc).await.unwrap();
     assert!(geoip_lookup.mullvad_exit_ip, "Exit ip is not from Mullvad");
-    assert_eq!(
-        geoip_lookup.mullvad_exit_ip_hostname,
-        relay.hostname
-    );
+    assert_eq!(geoip_lookup.mullvad_exit_ip_hostname, relay.hostname);
 
     disconnect_and_wait(&mut mullvad_client).await?;
 

--- a/test-manager/src/vm/mod.rs
+++ b/test-manager/src/vm/mod.rs
@@ -10,6 +10,7 @@ pub mod network;
 mod provision;
 mod qemu;
 mod ssh;
+#[cfg(target_os = "macos")]
 mod tart;
 mod update;
 mod util;
@@ -46,11 +47,14 @@ pub async fn run(config: &Config, name: &str) -> Result<Box<dyn VmInstance>> {
                 .await
                 .context("Failed to run QEMU VM")?,
         ) as Box<_>,
+        #[cfg(target_os = "macos")]
         VmType::Tart => Box::new(
             tart::run(config, vm_conf)
                 .await
                 .context("Failed to run Tart VM")?,
         ) as Box<_>,
+        #[cfg(not(target_os = "macos"))]
+        VmType::Tart => return Err(anyhow::anyhow!("Failed to run Tart VM on a non-macOS host")),
     };
 
     log::info!("Started instance of \"{name}\" vm");

--- a/test-manager/src/vm/network/linux.rs
+++ b/test-manager/src/vm/network/linux.rs
@@ -48,16 +48,20 @@ data_encoding_macro::base64_array!(
 );
 
 /// "Real" (non-tunnel) IP of the wireguard remote peer as defined in `setup-network.sh`.
+#[allow(dead_code)]
 pub const CUSTOM_TUN_REMOTE_REAL_ADDR: Ipv4Addr = Ipv4Addr::new(172, 29, 1, 200);
 /// Port of the wireguard remote peer as defined in `setup-network.sh`.
+#[allow(dead_code)]
 pub const CUSTOM_TUN_REMOTE_REAL_PORT: u16 = 51820;
 /// Tunnel address of the wireguard local peer as defined in `setup-network.sh`.
 pub const CUSTOM_TUN_LOCAL_TUN_ADDR: Ipv4Addr = Ipv4Addr::new(192, 168, 15, 2);
 /// Tunnel address of the wireguard remote peer as defined in `setup-network.sh`.
 pub const CUSTOM_TUN_REMOTE_TUN_ADDR: Ipv4Addr = Ipv4Addr::new(192, 168, 15, 1);
 /// Gateway (and default DNS resolver) of the wireguard tunnel.
+#[allow(dead_code)]
 pub const CUSTOM_TUN_GATEWAY: Ipv4Addr = CUSTOM_TUN_REMOTE_TUN_ADDR;
 /// Gateway of the non-tunnel interface.
+#[allow(dead_code)]
 pub const NON_TUN_GATEWAY: Ipv4Addr = Ipv4Addr::new(172, 29, 1, 1);
 /// Name of the wireguard interface on the host
 pub const CUSTOM_TUN_INTERFACE_NAME: &str = "wg-relay0";

--- a/test-manager/src/vm/network/mod.rs
+++ b/test-manager/src/vm/network/mod.rs
@@ -1,8 +1,10 @@
+// #[cfg(target_os = "linux")]
 pub mod linux;
-pub mod macos;
-
 #[cfg(target_os = "linux")]
 pub use linux as platform;
+
+#[cfg(target_os = "macos")]
+pub mod macos;
 #[cfg(target_os = "macos")]
 pub use macos as platform;
 

--- a/test-runner/src/net.rs
+++ b/test-runner/src/net.rs
@@ -1,14 +1,14 @@
 use socket2::SockAddr;
+#[cfg(target_os = "macos")]
+use std::{ffi::CString, num::NonZeroU32};
 use std::{
-    ffi::{CStr, CString},
     net::{IpAddr, SocketAddr},
-    num::NonZeroU32,
     process::Output,
 };
 use test_rpc::Interface;
 use tokio::{
     io::AsyncWriteExt,
-    net::{TcpSocket, TcpStream, UdpSocket},
+    net::{TcpStream, UdpSocket},
     process::Command,
 };
 

--- a/test-runner/src/package.rs
+++ b/test-runner/src/package.rs
@@ -1,6 +1,7 @@
+#[cfg(target_os = "linux")]
+use std::path::Path;
 use std::{
     collections::HashMap,
-    path::Path,
     process::{Output, Stdio},
 };
 use test_rpc::package::{Error, Package, Result};
@@ -27,7 +28,7 @@ pub async fn uninstall_app(env: HashMap<String, String>) -> Result<()> {
         .await
         .map_err(|e| strip_error(Error::WriteFile, e))?;
 
-    for (k, _) in &env {
+    for k in env.keys() {
         sudoers
             .write_all(format!("\nDefaults env_keep += \"{k}\"").as_bytes())
             .await


### PR DESCRIPTION
This small PR just cleans up the remaining `clippy` warnings in the repository.

As the PR is based on #91 it is preferably rebased on top of main after that one is merged. It would also be nice to squash all of these commits into one commit before merge :nerd_face:

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app-tests/93)
<!-- Reviewable:end -->
