### PR TITLE
Add more eye candy to test results HTML output

### DIFF
--- a/test-manager/src/summary.rs
+++ b/test-manager/src/summary.rs
@@ -240,8 +240,10 @@ pub async fn print_summary_table<P: AsRef<Path>>(summary_files: &[P]) -> Result<
                 .get(test.name)
                 .unwrap_or(&TestResult::Unknown);
             match result {
-                TestResult::Fail => failed_platforms.push(summary.name.clone()),
-                TestResult::Pass | TestResult::Unknown => (),
+                TestResult::Fail | TestResult::Unknown => {
+                    failed_platforms.push(summary.name.clone())
+                }
+                TestResult::Pass => (),
             }
             println!("<td style='text-align: center;'>{}</td>", result);
         }


### PR DESCRIPTION
Make the test output HTML easier to parse at a glance by adding some distinct icons/colors to distinguish the result of each test, as well as a counter for displaying the ratio between passing tests & the total number of test.

## Examples
### Some test(s) failed
![image](https://github.com/mullvad/mullvadvpn-app-tests/assets/31306191/abdc2a9f-43b3-4131-9412-039f660c7b7c)

### All tests passed
![image](https://github.com/mullvad/mullvadvpn-app-tests/assets/31306191/38c277b7-b9e5-4904-877e-d41094ce696f)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app-tests/97)
<!-- Reviewable:end -->
