### PR TITLE
Actually create array of OSes in CI script

### DIFF
--- a/ci-runtests.sh
+++ b/ci-runtests.sh
@@ -29,7 +29,11 @@ echo "* Version to upgrade from: $OLD_APP_VERSION"
 echo "* Version to test: $NEW_APP_VERSION"
 echo "**********************************"
 
-TEST_OSES=(${TEST_OSES-"debian11 debian12 ubuntu2004 ubuntu2204 ubuntu2304 fedora38 fedora37 fedora36 windows10 windows11"})
+DEFAULT_OSES=(debian11 debian12 ubuntu2004 ubuntu2204 ubuntu2304 fedora38 fedora37 fedora36 windows10 windows11)
+# Try to parse $TEST_OSES from the environment
+# https://www.shellcheck.net/wiki/SC2206
+IFS=" " read -r -a TEST_OSES <<< "$TEST_OSES"
+TEST_OSES=( "${TEST_OSES[@]:-"${DEFAULT_OSES[@]}"}" )
 
 if [[ -z "${ACCOUNT_TOKENS+x}" ]]; then
     echo "'ACCOUNT_TOKENS' must be specified" 1>&2


### PR DESCRIPTION
Previously, the array of OSes would be interpreted as a string, which would make the `os` argument of the `download_e2e_executable` function be equal to the string of all `TEST_OSES`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app-tests/99)
<!-- Reviewable:end -->
