### PR TITLE
Refactor/generalize relay selection in `test_connected_state`

### DIFF
--- a/test-manager/src/tests/helpers.rs
+++ b/test-manager/src/tests/helpers.rs
@@ -614,7 +614,7 @@ pub fn flatten_relaylist(relays: types::RelayList) -> Vec<types::Relay> {
 ///
 /// Returns an [`Option`] because a [`Relay`] is not guaranteed to be poplutaed with a location
 /// vaule.
-pub fn into_constraint(relay: types::Relay) -> Option<Constraint<LocationConstraint>> {
+pub fn into_constraint(relay: &types::Relay) -> Option<Constraint<LocationConstraint>> {
     into_locationconstraint(relay).map(Constraint::Only)
 }
 
@@ -622,16 +622,21 @@ pub fn into_constraint(relay: types::Relay) -> Option<Constraint<LocationConstra
 ///
 /// Returns an [`Option`] because a [`Relay`] is not guaranteed to be poplutaed with a location
 /// vaule.
-pub fn into_locationconstraint(relay: types::Relay) -> Option<LocationConstraint> {
+pub fn into_locationconstraint(relay: &types::Relay) -> Option<LocationConstraint> {
     relay
         .location
+        .as_ref()
         .map(
             |types::Location {
                  country_code,
                  city_code,
                  ..
              }| {
-                GeographicLocationConstraint::Hostname(country_code, city_code, relay.hostname)
+                GeographicLocationConstraint::Hostname(
+                    country_code.to_string(),
+                    city_code.to_string(),
+                    relay.hostname.to_string(),
+                )
             },
         )
         .map(LocationConstraint::Location)

--- a/test-manager/src/tests/tunnel.rs
+++ b/test-manager/src/tests/tunnel.rs
@@ -244,7 +244,7 @@ pub async fn test_bridge(
         .set_bridge_settings(types::BridgeSettings {
             r#type: Some(types::bridge_settings::Type::Normal(
                 types::bridge_settings::BridgeConstraints {
-                    location: helpers::into_locationconstraint(entry.clone())
+                    location: helpers::into_locationconstraint(&entry)
                         .map(types::LocationConstraint::from),
                     providers: vec![],
                     ownership: i32::from(types::Ownership::Any),
@@ -255,7 +255,7 @@ pub async fn test_bridge(
         .expect("failed to update bridge settings");
 
     let relay_settings = RelaySettingsUpdate::Normal(RelayConstraintsUpdate {
-        location: helpers::into_constraint(exit.clone()),
+        location: helpers::into_constraint(&exit),
         tunnel_protocol: Some(Constraint::Only(TunnelType::OpenVpn)),
         ..Default::default()
     });
@@ -325,9 +325,9 @@ pub async fn test_multihop(
         relay.active && relay.endpoint_type == i32::from(types::relay::RelayType::Wireguard)
     };
     let (entry, exit) = helpers::random_entry_and_exit(&mut mullvad_client, relay_filter).await?;
-    let exit_constraint = helpers::into_constraint(exit.clone());
+    let exit_constraint = helpers::into_constraint(&exit);
     let entry_constraint =
-        helpers::into_constraint(entry.clone()).map(|entry_location| WireguardConstraints {
+        helpers::into_constraint(&entry).map(|entry_location| WireguardConstraints {
             use_multihop: true,
             entry_location,
             ..Default::default()

--- a/test-manager/src/tests/ui.rs
+++ b/test-manager/src/tests/ui.rs
@@ -97,7 +97,7 @@ pub async fn test_ui_tunnel_settings(
 
     // The test expects us to be disconnected and logged in but to have a specific relay selected
     let relay_settings = RelaySettingsUpdate::Normal(RelayConstraintsUpdate {
-        location: helpers::into_constraint(entry.clone()),
+        location: helpers::into_constraint(&entry),
         ..Default::default()
     });
 


### PR DESCRIPTION
Fix long-standing `TODO` comment in test case `test_connected_state`. The relay used in the test is no longer hard coded, which makes the test more robust to changes in the testing environment.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app-tests/100)
<!-- Reviewable:end -->
