### PR TITLE
Fix missing default value for `$TEST_OSES` in `ci-runtests.sh`

### DIFF
--- a/ci-runtests.sh
+++ b/ci-runtests.sh
@@ -32,7 +32,7 @@ echo "**********************************"
 DEFAULT_OSES=(debian11 debian12 ubuntu2004 ubuntu2204 ubuntu2304 fedora38 fedora37 fedora36 windows10 windows11)
 # Try to parse $TEST_OSES from the environment
 # https://www.shellcheck.net/wiki/SC2206
-IFS=" " read -r -a TEST_OSES <<< "$TEST_OSES"
+IFS=" " read -r -a TEST_OSES <<< "${TEST_OSES:-}"
 TEST_OSES=( "${TEST_OSES[@]:-"${DEFAULT_OSES[@]}"}" )
 
 if [[ -z "${ACCOUNT_TOKENS+x}" ]]; then


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app-tests/103)
<!-- Reviewable:end -->
