### PR TITLE
Fix `test-runner` Windows build

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,38 @@ dnf install git gcc protobuf-devel libpcap-devel qemu \
 rustup target add x86_64-pc-windows-gnu
 ```
 
+# Building the test runner
+
+Building the `test-runner` binary is done with the `build.sh` script.
+Currently, only `x86_64` platforms are supported for Windows/Linux and `ARM64` (Apple Silicon) for macOS.
+
+The `build.sh` requires the `$TARGET` environment variable to be set.
+For example, building `test-runner` for Linux would look like this:
+
+``` bash
+TARGET=x86_64-unknown-linux-gnu ./build.sh
+```
+
+## Linux
+For a Linux target `podman` is required to build the `test-runner`. See the [Linux section under Prerequisities](#Prerequisities) for more details.
+
+``` bash
+TARGET=x86_64-unknown-linux-gnu ./build.sh
+```
+
+## macOS
+
+``` bash
+TARGET=aarch64-apple-darwin ./build.sh
+```
+
+## Windows
+The `test-runner` binary for Windows may be cross-compiled from a Linux host.
+
+``` bash
+TARGET=x86_64-pc-windows-gnu ./build.sh
+```
+
 # Building base images
 
 See [`BUILD_OS_IMAGE.md`](./BUILD_OS_IMAGE.md) for how to build images for running tests on.

--- a/test-runner/src/package.rs
+++ b/test-runner/src/package.rs
@@ -1,4 +1,4 @@
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "windows"))]
 use std::path::Path;
 use std::{
     collections::HashMap,

--- a/test-runner/src/sys.rs
+++ b/test-runner/src/sys.rs
@@ -108,7 +108,7 @@ fn grant_shutdown_privilege() -> Result<(), test_rpc::Error> {
         AdjustTokenPrivileges(
             token_handle,
             0,
-            &mut privileges,
+            &privileges,
             0,
             std::ptr::null_mut(),
             std::ptr::null_mut(),


### PR DESCRIPTION
I accidentally broke `test-runner` builds for Windows in #93, so this PR fixes that while cleaning up the remaining `clippy` complaints (for Windows specifically) :crossed_fingers: 

I went ahead and added a section in the `README`  about building the `test-runner` for different platforms. I totally blanked on Windows being a target in the first place, so hopefully this will serve as a reminder on what to test before trying to merge conditional compilation stuff :sweat_smile:

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app-tests/104)
<!-- Reviewable:end -->
