### PR TITLE
Fix nonrobust tests

### DIFF
--- a/test-manager/src/tests/helpers.rs
+++ b/test-manager/src/tests/helpers.rs
@@ -16,9 +16,7 @@ use std::{
     time::Duration,
 };
 use talpid_types::net::wireguard::{PeerConfig, PrivateKey, TunnelConfig};
-use test_rpc::{
-    mullvad_daemon::ServiceStatus, package::Package, AmIMullvad, Interface, ServiceClient,
-};
+use test_rpc::{package::Package, AmIMullvad, Interface, ServiceClient};
 use tokio::time::timeout;
 
 #[macro_export]
@@ -302,34 +300,6 @@ async fn find_next_tunnel_state_inner(
             }
             None => break Err(Error::DaemonError(String::from("Lost daemon event stream"))),
         }
-    }
-}
-
-/// Wait for the Mullvad system service to enter a specified state
-pub async fn wait_for_mullvad_service_state(
-    rpc: &ServiceClient,
-    accept_state_fn: impl Fn(ServiceStatus) -> bool,
-) -> Result<(), Error> {
-    const MAX_ATTEMPTS: usize = 10;
-    const POLL_INTERVAL: Duration = Duration::from_secs(3);
-
-    let mut attempt = 0;
-
-    loop {
-        let last_state = rpc.mullvad_daemon_get_status().await?;
-        if accept_state_fn(last_state) {
-            break Ok(());
-        }
-
-        attempt += 1;
-        if attempt >= MAX_ATTEMPTS {
-            break Err(match last_state {
-                ServiceStatus::NotRunning => Error::DaemonNotRunning,
-                ServiceStatus::Running => Error::DaemonRunning,
-            });
-        }
-
-        tokio::time::sleep(POLL_INTERVAL).await;
     }
 }
 

--- a/test-manager/src/tests/install.rs
+++ b/test-manager/src/tests/install.rs
@@ -327,6 +327,11 @@ pub async fn test_install_new_app(_: TestContext, rpc: ServiceClient) -> Result<
     rpc.install_app(get_package_desc(&TEST_CONFIG.current_app_filename)?)
         .await?;
 
+    // verify that daemon is running
+    if rpc.mullvad_daemon_get_status().await? != ServiceStatus::Running {
+        return Err(Error::DaemonNotRunning);
+    }
+
     // Set the log level to trace
     rpc.set_daemon_log_level(test_rpc::mullvad_daemon::Verbosity::Trace)
         .await?;
@@ -335,11 +340,6 @@ pub async fn test_install_new_app(_: TestContext, rpc: ServiceClient) -> Result<
 
     // Override env vars
     rpc.set_daemon_environment(get_app_env()).await?;
-
-    // verify that daemon is running
-    if rpc.mullvad_daemon_get_status().await? != ServiceStatus::Running {
-        return Err(Error::DaemonNotRunning);
-    }
 
     Ok(())
 }

--- a/test-manager/src/tests/tunnel.rs
+++ b/test-manager/src/tests/tunnel.rs
@@ -413,7 +413,8 @@ pub async fn test_wireguard_autoconnect(
         .expect("failed to enable auto-connect");
 
     reboot(&mut rpc).await?;
-    helpers::wait_for_mullvad_service_state(&rpc, |state| state == ServiceStatus::Running).await?;
+    rpc.mullvad_daemon_wait_for_state(|state| state == ServiceStatus::Running)
+        .await?;
 
     log::info!("Waiting for daemon to connect");
 
@@ -457,7 +458,8 @@ pub async fn test_openvpn_autoconnect(
         .expect("failed to enable auto-connect");
 
     reboot(&mut rpc).await?;
-    helpers::wait_for_mullvad_service_state(&rpc, |state| state == ServiceStatus::Running).await?;
+    rpc.mullvad_daemon_wait_for_state(|state| state == ServiceStatus::Running)
+        .await?;
 
     log::info!("Waiting for daemon to connect");
 

--- a/test-rpc/src/lib.rs
+++ b/test-rpc/src/lib.rs
@@ -51,6 +51,8 @@ pub enum Error {
     UserNotLoggedIn(String),
     #[error(display = "Invalid URL")]
     InvalidUrl,
+    #[error(display = "Timeout")]
+    Timeout,
 }
 
 #[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone, Copy)]

--- a/test-runner/src/main.rs
+++ b/test-runner/src/main.rs
@@ -104,10 +104,7 @@ impl Service for TestServer {
         self,
         _: context::Context,
     ) -> test_rpc::mullvad_daemon::ServiceStatus {
-        match Path::new(SOCKET_PATH).exists() {
-            true => ServiceStatus::Running,
-            false => ServiceStatus::NotRunning,
-        }
+        get_pipe_status()
     }
 
     async fn find_mullvad_app_traces(
@@ -269,6 +266,13 @@ impl Service for TestServer {
 
     async fn make_device_json_old(self, _: context::Context) -> Result<(), test_rpc::Error> {
         app::make_device_json_old().await
+    }
+}
+
+fn get_pipe_status() -> ServiceStatus {
+    match Path::new(SOCKET_PATH).exists() {
+        true => ServiceStatus::Running,
+        false => ServiceStatus::NotRunning,
     }
 }
 


### PR DESCRIPTION
A couple of small changes:
* `test_content_blockers` fails once in a blue moon. Likely because `set_dns_options` isn't guaranteed to take effect *immediately*.
* `test_install_new_app` fails once in a blue moon. Sleep for a while after restarting the daemon. The UDS isn't necessarily immediately available as soon as the service is running.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app-tests/105)
<!-- Reviewable:end -->
