### PR TITLE
Set priority for device tests

### DIFF
--- a/test-manager/src/tests/account.rs
+++ b/test-manager/src/tests/account.rs
@@ -57,7 +57,7 @@ pub async fn test_logout(
 }
 
 /// Try to log in when there are too many devices. Make sure it fails as expected.
-#[test_function(priority = -150)]
+#[test_function(priority = -151)]
 pub async fn test_too_many_devices(
     _: TestContext,
     rpc: ServiceClient,


### PR DESCRIPTION
When `test_revoked_device` fails, it may leave the daemon in a logged in state. The quick fix here is to run `test_revoked_device` last.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app-tests/106)
<!-- Reviewable:end -->
